### PR TITLE
Revert "SWC-4928: add status page incident report widget."

### DIFF
--- a/app-template/public/index.html
+++ b/app-template/public/index.html
@@ -64,9 +64,6 @@
       To begin the development, run `npm start` or `yarn start`.
       To create a production bundle, use `npm run build` or `yarn build`.
     -->
-    
-    <!-- SWC-4928: Report Synapse status, scheduled maintenance or incidents -->
-    <script src="https://kh896k90gyvg.statuspage.io/embed/script.js"></script>
   </body>
   <script>
     // setup pendo


### PR DESCRIPTION
Reverts Sage-Bionetworks/portals#57

This embedded widget caused errors to show up in the console (unsupported svg param values?), which caused some versions of Safari to crash.  Recommend reverting, and either try again with an updated widget from statuspage.io, or write a new component that uses their api.