### PR TITLE
UI Tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 app-template/ is the main react app template that reads a standard configuration file.
 
-configurations/ is a directory of configurations for portal development.
+configurations/ is a directory of configurations for portal development. See configurations/README.md on local developement.
 
 # Build Process
 ./run.sh

--- a/app-template/package.json
+++ b/app-template/package.json
@@ -22,7 +22,7 @@
     "react-spinners": "^0.6.1",
     "sass": "^1.5.1",
     "source-map-explorer": "^1.6.0",
-    "synapse-react-client": "1.12.59",
+    "synapse-react-client": "1.12.60",
     "typescript": "3.5.3"
   },
   "scripts": {

--- a/app-template/public/index.html
+++ b/app-template/public/index.html
@@ -10,6 +10,7 @@
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
     -->
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+    <link rel="robots" href="%PUBLIC_URL%/robots.txt" />
     <!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.

--- a/app-template/public/index.html
+++ b/app-template/public/index.html
@@ -10,7 +10,6 @@
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
     -->
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
-    <link rel="robots" href="%PUBLIC_URL%/robots.txt" />
     <!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.

--- a/app-template/src/AppInitializer.tsx
+++ b/app-template/src/AppInitializer.tsx
@@ -1,23 +1,25 @@
 import * as React from 'react'
 import { withRouter, RouteComponentProps } from 'react-router-dom'
 import docTitleConfig from './config/docTitleConfig'
-import { SynapseClient } from 'synapse-react-client'
+import { SynapseClient, SynapseConstants } from 'synapse-react-client'
 import { withCookies, ReactCookieProps } from 'react-cookie'
 import { DOWNLOAD_FILES_MENU_TEXT }  from 'synapse-react-client/dist/containers/SynapseTable';
-export type AppInitializerToken = {
+export type AppInitializerState = {
   token: string
+  showLoginDialog: boolean
 }
 // pendo's declaration should be picked up by node_modules/@types/pendo-io-browser but is not
 declare var pendo: any
 export const TokenContext = React.createContext('')
 
 type Props = RouteComponentProps & ReactCookieProps
-class AppInitializer extends React.Component<Props, AppInitializerToken> {
+class AppInitializer extends React.Component<Props, AppInitializerState> {
 
-  constructor(props: any) {
+  constructor(props: Props) {
     super(props)
     this.state = {
-      token: ''
+      token: '',
+      showLoginDialog: false
     }
     this.initializePendo = this.initializePendo.bind(this)
     this.updateSynapseCallbackCookie = this.updateSynapseCallbackCookie.bind(this)
@@ -44,6 +46,9 @@ class AppInitializer extends React.Component<Props, AppInitializerToken> {
       }).catch((_err) => {
         console.log('no token from cookie could be fetched ', _err)
         this.initializePendo()
+        // Clear their session token since its stale, components below can then safely check if the user is signed
+        // by checking if token is defined or not
+        SynapseClient.signOut()
       })
     // Technically, the AppInitializer is only mounted once during the portal app lifecycle.
     // But it's best practice to clean up the global listener on component unmount.
@@ -78,6 +83,18 @@ class AppInitializer extends React.Component<Props, AppInitializerToken> {
   componentWillUnmount() {
     window.removeEventListener('click', this.updateSynapseCallbackCookie)
   }
+  
+  onSignIn = (_event: any) => {
+    this.setState({
+      showLoginDialog: true
+    })
+  }
+
+  handleCloseLoginDialog = () => {
+    this.setState({
+      showLoginDialog: false
+    })
+  }
 
   componentDidUpdate(prevProps: Props) {
     // https://github.com/ReactTraining/react-router/blob/master/packages/react-router-dom/docs/guides/scroll-restoration.md
@@ -100,6 +117,20 @@ class AppInitializer extends React.Component<Props, AppInitializerToken> {
   render() {
     return (
       <TokenContext.Provider value={this.state.token}>
+        {
+          React.Children.map(this.props.children, (child: any) => {
+            if (!child) {
+              return false
+            } else {
+              const props = {
+                showLoginDialog: this.state.showLoginDialog,
+                show: this.onSignIn,
+                handleCloseLoginDialog: this.handleCloseLoginDialog
+              }
+              return React.cloneElement(child, props)
+            }
+          })
+        }
         {this.props.children}
       </TokenContext.Provider>
     )
@@ -120,6 +151,12 @@ class AppInitializer extends React.Component<Props, AppInitializerToken> {
     if (ev.target instanceof HTMLAnchorElement) {
       const anchorElement = ev.target as HTMLAnchorElement
       isInvokingDownloadTable = anchorElement.text === DOWNLOAD_FILES_MENU_TEXT
+    }
+    if (ev.target instanceof HTMLButtonElement) {
+      const buttonElement = ev.target as HTMLButtonElement
+      if (buttonElement.classList.contains(SynapseConstants.SRC_SIGN_IN_CLASS)) {
+        this.setState({ showLoginDialog: true })
+      }
     }
     let color = 'white'
     let background = '#4db7ad'

--- a/app-template/src/AppInitializer.tsx
+++ b/app-template/src/AppInitializer.tsx
@@ -131,7 +131,6 @@ class AppInitializer extends React.Component<Props, AppInitializerState> {
             }
           })
         }
-        {this.props.children}
       </TokenContext.Provider>
     )
   }

--- a/app-template/src/Navbar.tsx
+++ b/app-template/src/Navbar.tsx
@@ -16,11 +16,15 @@ export type NavbarState = {
   [index:string]: any,
   token: string | undefined,
   userprofile: UserProfile | undefined,
-  showLoginDialog: boolean,
+}
+export type InternalNavbarProps = {
+  showLoginDialog: boolean
+  onSignIn: Function
+  handleCloseLoginDialog: Function
 }
 export class Navbar extends React.Component<{}, NavbarState> {
 
-  constructor(props: any) {
+  constructor(props: InternalNavbarProps) {
     super(props)
     const numNestedRoutes = routesConfig.filter(el => el.isNested).length
     const state: NavbarState = {
@@ -67,19 +71,7 @@ export class Navbar extends React.Component<{}, NavbarState> {
       usermenu: !this.state.usermenu
     })
   }
-
-  onSignIn = (_event: any) => {
-    this.setState({
-      showLoginDialog: true
-    })
-  }
-
-  handleCloseLoginDialog = () => {
-    this.setState({
-      showLoginDialog: false
-    })
-  }
-
+  
   // given the hash, decide if the link should have a bottom border
   getBorder = (name: string) => {
     if (name === '') {
@@ -115,6 +107,11 @@ export class Navbar extends React.Component<{}, NavbarState> {
   render() {
     const goToTop = (_event:any) => { window.scroll({ top: 0 }) }
     const { hasDropdownOpen } = this.state
+    const {
+      onSignIn,
+      handleCloseLoginDialog,
+      showLoginDialog
+    } = this.props as InternalNavbarProps
     const toggleOff = this.toggleDropdown(-1)
     let currentNestedRouteCount = 0
     const { name, icon } = logoHeaderConfig
@@ -145,11 +142,15 @@ export class Navbar extends React.Component<{}, NavbarState> {
                   <button
                     id="signin-button"
                     className="SRC-primary-text-color-background"
-                    onClick={this.onSignIn}
+                    // @ts-ignore
+                    onClick={onSignIn}
                   >
                     SIGN&nbsp;IN
                   </button>
-                  <Dialog onClose={this.handleCloseLoginDialog} open={this.state.showLoginDialog}>
+                  <Dialog 
+                    // @ts-ignore
+                    onClose={handleCloseLoginDialog}
+                    open={showLoginDialog}>
                     <SynapseComponents.Login
                         token={this.state.token}
                         theme={'light'}

--- a/app-template/yarn.lock
+++ b/app-template/yarn.lock
@@ -10281,9 +10281,9 @@ symbol-tree@^3.2.2:
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"
 
-synapse-react-client@1.12.59:
-  version "1.12.59"
-  resolved "https://registry.yarnpkg.com/synapse-react-client/-/synapse-react-client-1.12.59.tgz#778f2b39e07f0834990f975cec4a5d1bf2aa5ff4"
+synapse-react-client@1.12.60:
+  version "1.12.60"
+  resolved "https://registry.yarnpkg.com/synapse-react-client/-/synapse-react-client-1.12.60.tgz#2ffbabebba3e9b766a36b39179c1324ca7e9fc1c"
   dependencies:
     "@fortawesome/fontawesome-svg-core" "^1.2.4"
     "@fortawesome/free-solid-svg-icons" "^5.3.1"

--- a/configurations/README.md
+++ b/configurations/README.md
@@ -3,6 +3,5 @@
 1.  `cp -r config-shell [portal-name]`
 2.   Fill in the needed TODOs from the config-shell template
 
-
 # Developing locally (mac instructions)
-1. Run ./linkConfig [portal-name] to run the portal locally
+1. Run `./linkConfig [portal-name]` to run the portal locally

--- a/configurations/package.json
+++ b/configurations/package.json
@@ -5,7 +5,7 @@
   "repository": "git@github.com:leem42/portals.git",
   "author": "Michael Lee <michael.leem42@gmail.com>",
   "devDependencies": {
-    "synapse-react-client": "1.12.59",
+    "synapse-react-client": "1.12.60",
     "typescript": "3.5.3"
   },
   "scripts": {


### PR DESCRIPTION
Added listener for sign in clicks, hoisted state for login as a result so that AppInitializer could show the modal.

Added signout call if refresh token fails --- clearing the token and _in theory_ letting components that are using the token assert that the person is not logged in by whether the token is defined or not, since a stale token would never get passed in.

Bump SRC
