### PR TITLE
fix issues with types being dropped

### DIFF
--- a/app-template/src/portal-components/QueryWrapperFlattened.tsx
+++ b/app-template/src/portal-components/QueryWrapperFlattened.tsx
@@ -15,7 +15,7 @@ type SearchParams = {
   }
 }
 type Operator = {
-  sqlOperator: SQLOperator
+  sqlOperator?: SQLOperator
 }
 export type QueryWrapperFlattenedProps = QueryWrapperProps &
   Partial<StackedBarChartProps> &

--- a/app-template/src/test-configuration/exploreHomeConfiguration/publications.ts
+++ b/app-template/src/test-configuration/exploreHomeConfiguration/publications.ts
@@ -46,7 +46,7 @@ export const publications: HomeExploreConfig = {
       name: 'Publications',
       cardConfiguration: {
         type: SynapseConstants.GENERIC_CARD,
-        genericCardConfiguration: publicationSchema,
+        genericCardSchema: publicationSchema,
       },
       menuConfig: [
         {

--- a/app-template/src/test-configuration/routesConfig.ts
+++ b/app-template/src/test-configuration/routesConfig.ts
@@ -69,6 +69,7 @@ routes[ORGANIZATION_INDEX] = {
             type: SynapseConstants.GENERIC_CARD,
             genericCardSchema: {
               title: 'name',
+              type: SynapseConstants.PUBLICATION,
             },
             sql: `SELECT * FROM syn18488466 WHERE ( ( "featured" = 'TRUE' ) )`,
           },
@@ -119,6 +120,7 @@ routes[HOME_INDEX] = {
         type: SynapseConstants.GENERIC_CARD,
         genericCardSchema: {
           title: 'name',
+          type: SynapseConstants.PUBLICATION,
         },
         limit: 3,
       },

--- a/app-template/src/types/portal-config.d.ts
+++ b/app-template/src/types/portal-config.d.ts
@@ -1,5 +1,13 @@
-/// <reference types="synapse-react-client" />
-
+import { CardContainerLogicProps } from 'synapse-react-client/dist/containers/CardContainerLogic'
+import { QueryWrapperProps } from 'synapse-react-client/dist/containers/QueryWrapper'
+import { StackedBarChartProps } from 'synapse-react-client/dist/containers/StackedBarChart'
+import { SynapseTableProps } from 'synapse-react-client/dist/containers/SynapseTable'
+import { QueryWrapperMenuProps } from 'synapse-react-client/dist/containers/QueryWrapperMenu'
+import { UserCardProps } from 'synapse-react-client/dist/containers/UserCard'
+import { MarkdownSynapseProps } from 'synapse-react-client/dist/containers/MarkdownSynapse'
+import { NewsFeedMenuProps } from 'synapse-react-client/dist/containers/NewsFeedMenu'
+import { SynapseFormSubmissionGridProps } from 'synapse-react-client/dist/containers/synapse_form_wrapper/SynapseFormSubmissionsGrid'
+import { SynapseFormWrapperProps } from 'synapse-react-client/dist/containers/synapse_form_wrapper/SynapseFormWrapper'
 import { StatefulButtonControlProps } from '../portal-components/StatefulButtonControlWrapper'
 import { RouteButtonControlProps } from '../portal-components/RouteButtonControlWrapper'
 
@@ -10,9 +18,9 @@ export type HomePageHeaderConfig = {
 }
 
 // Generic SynapseConfigArray Representation -- maps each component to its props
-declare type CardContainerLogic = {
-  name: 'CardContainerLogic'
+type CardContainerLogic = {
   props: CardContainerLogicProps
+  name: 'CardContainerLogic'
 }
 
 type QueryWrapper = {
@@ -28,7 +36,7 @@ type QueryWrapperFlattened = {
     Partial<SynapseTableProps>
 }
 
-declare type StackedBarChart = {
+type StackedBarChart = {
   name: 'StackedBarChart'
   props: StackedBarChartProps
 }
@@ -43,7 +51,7 @@ type UserCard = {
 }
 type Markdown = {
   name: 'Markdown'
-  props: MarkdownProps
+  props: MarkdownSynapseProps
 }
 
 type StatefulButtonControl = {
@@ -77,14 +85,14 @@ type NewsFeedMenu = {
   props: NewsFeedMenuProps
 }
 
-type SynapseForm = {
-  name: 'SynapseForm'
-  props: SynapseFormProps
+type SynapseFormWrapper = {
+  name: 'SynapseFormWrapper'
+  props: SynapseFormWrapperProps
 }
 
 type SynapseFormSubmissionsGrid = {
   name: 'SynapseFormSubmissionsGrid'
-  props: SynapseFormSubmissionsGridProps
+  props: SynapseFormSubmissionGridProps
 }
 
 export type SynapseConfig = (

--- a/app-template/src/types/portal-util-types.d.ts
+++ b/app-template/src/types/portal-util-types.d.ts
@@ -8,12 +8,12 @@ import { SQLOperator } from 'synapse-react-client/dist/utils/modules/sqlFunction
   the portal.
 */
 
-declare type HomeExploreConfig = {
+type HomeExploreConfig = {
   homePageSynapseObject: QueryWrapper
   explorePageSynapseObject: SynapseConfig
 }
 
-declare module '*.svg' {
+module '*.svg' {
   const content: string
   export default content
 }
@@ -35,7 +35,7 @@ type RowToPropTransform = {
 }
 
 export type RowSynapseConfig = SynapseConfig & RowToPropTransform
-export declare type GenerateComponentsFromRowProps = {
+export type GenerateComponentsFromRowProps = {
   showMenu?: boolean // default to true
   searchParams?: Dictionary<string>
   sql: string

--- a/configurations/adknowledgeportal/routesConfig.ts
+++ b/configurations/adknowledgeportal/routesConfig.ts
@@ -367,7 +367,6 @@ const routes: GenericRoute[] = [
       {
         name: 'SynapseFormWrapper',
         props: {
-          pathpart: '#/Contribute',
           formSchemaEntityId: 'syn20692910',
           fileNamePath: 'study.submission_name',
           formUiSchemaEntityId: 'syn20692911',

--- a/configurations/adknowledgeportal/synapseConfigs/programs.ts
+++ b/configurations/adknowledgeportal/synapseConfigs/programs.ts
@@ -16,6 +16,7 @@ const programs: SynapseConfig = {
       icon: 'Program',
     },
     titleLinkConfig: {
+      isMarkdown: false,
       baseURL: 'Explore/Programs',
       URLColumnNames: ['Program'],
     },

--- a/configurations/adknowledgeportal/synapseConfigs/projects.ts
+++ b/configurations/adknowledgeportal/synapseConfigs/projects.ts
@@ -1,6 +1,7 @@
 import { HomeExploreConfig } from '../../types/portal-config'
 import { SynapseConstants } from 'synapse-react-client'
 import loadingScreen from '../loadingScreen'
+import { CardConfiguration } from 'synapse-react-client/dist/containers/CardContainerLogic'
 
 const unitDescription = 'Projects'
 const rgbIndex = 4
@@ -8,7 +9,7 @@ export const projectsSql = 'SELECT * FROM syn17024229'
 const sql = projectsSql
 const facet = 'Program'
 
-export const projectCardProps = {
+export const projectCardProps: CardConfiguration = {
   type: SynapseConstants.GENERIC_CARD,
   genericCardSchema: {
     type: 'Project',

--- a/configurations/adknowledgeportal/synapseConfigs/studies.ts
+++ b/configurations/adknowledgeportal/synapseConfigs/studies.ts
@@ -2,7 +2,10 @@ import { HomeExploreConfig, SynapseConfig } from '../../types/portal-config'
 import { GenerateComponentsFromRowProps } from '../../types/portal-util-types'
 import { SynapseConstants } from 'synapse-react-client'
 import loadingScreen from '../loadingScreen'
-import { CardConfiguration } from 'synapse-react-client/dist/containers/CardContainerLogic'
+import {
+  CardConfiguration,
+  CardLink,
+} from 'synapse-react-client/dist/containers/CardContainerLogic'
 import studyHeaderSvg from '../style/study-header.svg'
 
 const unitDescription = 'studies'
@@ -10,6 +13,11 @@ const rgbIndex = 0
 export const studiesSql = 'SELECT * FROM syn17083367'
 const sql = studiesSql
 const facet = 'Species'
+const cardLink: CardLink = {
+  isMarkdown: false,
+  baseURL: 'Explore/Studies',
+  URLColumnNames: ['Study'],
+}
 export const studyCardProps: CardConfiguration = {
   type: SynapseConstants.GENERIC_CARD,
   secondaryLabelLimit: 4,
@@ -135,7 +143,6 @@ const studies: HomeExploreConfig = {
         {
           sql,
           facet: 'Consortium',
-          facetAliases: 'Program',
         },
         {
           sql,

--- a/configurations/adknowledgeportal/synapseConfigs/studies.ts
+++ b/configurations/adknowledgeportal/synapseConfigs/studies.ts
@@ -13,11 +13,6 @@ const rgbIndex = 0
 export const studiesSql = 'SELECT * FROM syn17083367'
 const sql = studiesSql
 const facet = 'Species'
-const cardLink: CardLink = {
-  isMarkdown: false,
-  baseURL: 'Explore/Studies',
-  URLColumnNames: ['Study'],
-}
 export const studyCardProps: CardConfiguration = {
   type: SynapseConstants.GENERIC_CARD,
   secondaryLabelLimit: 4,

--- a/configurations/csbc-pson/routesConfig.ts
+++ b/configurations/csbc-pson/routesConfig.ts
@@ -75,6 +75,7 @@ const routes: GenericRoute[] = [
         link: 'Explore/Studies',
         props: {
           loadingScreen,
+          // @ts-ignore TODO: Remove after this prop is added to CardContainerLogic
           facetAliases,
           sql: studiesSql,
           limit: homeLimit,
@@ -210,6 +211,7 @@ const routes: GenericRoute[] = [
               backgroundColor: '#407ba0',
               genericCardSchema: studySchema,
               loadingScreen,
+              // @ts-ignore TODO: Remove after this prop is added to CardContainerLogic
               facetAliases,
               labelConfig: [
                 {

--- a/configurations/nf/routesConfig.ts
+++ b/configurations/nf/routesConfig.ts
@@ -70,6 +70,7 @@ const routes: GenericRoute[] = [
         props: {
           limit,
           loadingScreen,
+          // @ts-ignore TODO: Remove after this prop is added to CardContainerLogic
           facetAliases,
           sql: studiesSql,
           ...studiesCardConfiguration,
@@ -159,9 +160,10 @@ const routes: GenericRoute[] = [
               backgroundColor: '#119488',
               genericCardSchema: {
                 link: 'studyId',
-                ...studiesCardConfiguration.genericCardSchema,
+                ...studiesCardConfiguration.genericCardSchema!,
               },
               loadingScreen,
+              // @ts-ignore TODO: Remove after this prop is added to CardContainerLogic
               facetAliases,
               iconOptions: studyHeaderIconOptions,
               secondaryLabelLimit: Infinity,

--- a/configurations/package.json
+++ b/configurations/package.json
@@ -5,7 +5,7 @@
   "repository": "git@github.com:leem42/portals.git",
   "author": "Michael Lee <michael.leem42@gmail.com>",
   "devDependencies": {
-    "synapse-react-client": "1.12.84",
+    "synapse-react-client": "1.12.85",
     "typescript": "3.5.3"
   },
   "scripts": {

--- a/configurations/stopadportal/routesConfig.ts
+++ b/configurations/stopadportal/routesConfig.ts
@@ -42,7 +42,6 @@ const routes: GenericRoute[] = [
       {
         name: 'SynapseFormWrapper',
         props: {
-          pathpart: '#/Apply',
           formSchemaEntityId: 'syn20680102',
           fileNamePath: 'naming.compound_name',
           formUiSchemaEntityId: 'syn20693568',

--- a/configurations/yarn.lock
+++ b/configurations/yarn.lock
@@ -8,7 +8,7 @@
   dependencies:
     "@babel/highlight" "^7.0.0"
 
-"@babel/core@7.6.0", "@babel/core@^7.0.0", "@babel/core@^7.1.0", "@babel/core@^7.4.5":
+"@babel/core@7.6.0", "@babel/core@^7.1.0", "@babel/core@^7.4.5":
   version "7.6.0"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.6.0.tgz#9b00f73554edd67bebc86df8303ef678be3d7b48"
   dependencies:
@@ -27,6 +27,25 @@
     semver "^5.4.1"
     source-map "^0.5.0"
 
+"@babel/core@^7.7.2":
+  version "7.7.5"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.7.5.tgz#ae1323cd035b5160293307f50647e83f8ba62f7e"
+  dependencies:
+    "@babel/code-frame" "^7.5.5"
+    "@babel/generator" "^7.7.4"
+    "@babel/helpers" "^7.7.4"
+    "@babel/parser" "^7.7.5"
+    "@babel/template" "^7.7.4"
+    "@babel/traverse" "^7.7.4"
+    "@babel/types" "^7.7.4"
+    convert-source-map "^1.7.0"
+    debug "^4.1.0"
+    json5 "^2.1.0"
+    lodash "^4.17.13"
+    resolve "^1.3.2"
+    semver "^5.4.1"
+    source-map "^0.5.0"
+
 "@babel/generator@^7.4.0", "@babel/generator@^7.6.0":
   version "7.6.0"
   resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.6.0.tgz#e2c21efbfd3293ad819a2359b448f002bfdfda56"
@@ -36,6 +55,15 @@
     lodash "^4.17.13"
     source-map "^0.5.0"
     trim-right "^1.0.1"
+
+"@babel/generator@^7.7.4":
+  version "7.7.4"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.7.4.tgz#db651e2840ca9aa66f327dcec1dc5f5fa9611369"
+  dependencies:
+    "@babel/types" "^7.7.4"
+    jsesc "^2.5.1"
+    lodash "^4.17.13"
+    source-map "^0.5.0"
 
 "@babel/helper-annotate-as-pure@^7.0.0":
   version "7.0.0"
@@ -99,11 +127,25 @@
     "@babel/template" "^7.1.0"
     "@babel/types" "^7.0.0"
 
+"@babel/helper-function-name@^7.7.4":
+  version "7.7.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.7.4.tgz#ab6e041e7135d436d8f0a3eca15de5b67a341a2e"
+  dependencies:
+    "@babel/helper-get-function-arity" "^7.7.4"
+    "@babel/template" "^7.7.4"
+    "@babel/types" "^7.7.4"
+
 "@babel/helper-get-function-arity@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz#83572d4320e2a4657263734113c42868b64e49c3"
   dependencies:
     "@babel/types" "^7.0.0"
+
+"@babel/helper-get-function-arity@^7.7.4":
+  version "7.7.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.7.4.tgz#cb46348d2f8808e632f0ab048172130e636005f0"
+  dependencies:
+    "@babel/types" "^7.7.4"
 
 "@babel/helper-hoist-variables@^7.4.4":
   version "7.4.4"
@@ -182,6 +224,12 @@
   dependencies:
     "@babel/types" "^7.4.4"
 
+"@babel/helper-split-export-declaration@^7.7.4":
+  version "7.7.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.7.4.tgz#57292af60443c4a3622cf74040ddc28e68336fd8"
+  dependencies:
+    "@babel/types" "^7.7.4"
+
 "@babel/helper-wrap-function@^7.1.0":
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-wrap-function/-/helper-wrap-function-7.2.0.tgz#c4e0012445769e2815b55296ead43a958549f6fa"
@@ -199,6 +247,14 @@
     "@babel/traverse" "^7.6.0"
     "@babel/types" "^7.6.0"
 
+"@babel/helpers@^7.7.4":
+  version "7.7.4"
+  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.7.4.tgz#62c215b9e6c712dadc15a9a0dcab76c92a940302"
+  dependencies:
+    "@babel/template" "^7.7.4"
+    "@babel/traverse" "^7.7.4"
+    "@babel/types" "^7.7.4"
+
 "@babel/highlight@^7.0.0":
   version "7.5.0"
   resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.5.0.tgz#56d11312bd9248fa619591d02472be6e8cb32540"
@@ -210,6 +266,10 @@
 "@babel/parser@^7.0.0", "@babel/parser@^7.1.0", "@babel/parser@^7.4.3", "@babel/parser@^7.6.0":
   version "7.6.0"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.6.0.tgz#3e05d0647432a8326cb28d0de03895ae5a57f39b"
+
+"@babel/parser@^7.7.4", "@babel/parser@^7.7.5":
+  version "7.7.5"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.7.5.tgz#cbf45321619ac12d83363fcf9c94bb67fa646d71"
 
 "@babel/plugin-proposal-async-generator-functions@^7.2.0":
   version "7.2.0"
@@ -691,6 +751,14 @@
     "@babel/parser" "^7.6.0"
     "@babel/types" "^7.6.0"
 
+"@babel/template@^7.7.4":
+  version "7.7.4"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.7.4.tgz#428a7d9eecffe27deac0a98e23bf8e3675d2a77b"
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    "@babel/parser" "^7.7.4"
+    "@babel/types" "^7.7.4"
+
 "@babel/traverse@^7.0.0", "@babel/traverse@^7.1.0", "@babel/traverse@^7.4.3", "@babel/traverse@^7.4.4", "@babel/traverse@^7.5.5", "@babel/traverse@^7.6.0":
   version "7.6.0"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.6.0.tgz#389391d510f79be7ce2ddd6717be66d3fed4b516"
@@ -705,9 +773,31 @@
     globals "^11.1.0"
     lodash "^4.17.13"
 
+"@babel/traverse@^7.7.4":
+  version "7.7.4"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.7.4.tgz#9c1e7c60fb679fe4fcfaa42500833333c2058558"
+  dependencies:
+    "@babel/code-frame" "^7.5.5"
+    "@babel/generator" "^7.7.4"
+    "@babel/helper-function-name" "^7.7.4"
+    "@babel/helper-split-export-declaration" "^7.7.4"
+    "@babel/parser" "^7.7.4"
+    "@babel/types" "^7.7.4"
+    debug "^4.1.0"
+    globals "^11.1.0"
+    lodash "^4.17.13"
+
 "@babel/types@^7.0.0", "@babel/types@^7.2.0", "@babel/types@^7.3.0", "@babel/types@^7.4.0", "@babel/types@^7.4.4", "@babel/types@^7.5.5", "@babel/types@^7.6.0":
   version "7.6.1"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.6.1.tgz#53abf3308add3ac2a2884d539151c57c4b3ac648"
+  dependencies:
+    esutils "^2.0.2"
+    lodash "^4.17.13"
+    to-fast-properties "^2.0.0"
+
+"@babel/types@^7.7.4":
+  version "7.7.4"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.7.4.tgz#516570d539e44ddf308c07569c258ff94fde9193"
   dependencies:
     esutils "^2.0.2"
     lodash "^4.17.13"
@@ -720,9 +810,9 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
-"@comandeer/babel-plugin-banner@^4.0.0":
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/@comandeer/babel-plugin-banner/-/babel-plugin-banner-4.1.0.tgz#5f9f22f3ba5a4e87d0c972c402f039c6eeffc079"
+"@comandeer/babel-plugin-banner@^5.0.0":
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/@comandeer/babel-plugin-banner/-/babel-plugin-banner-5.0.0.tgz#30969cb08e810b67810d41761d0cfac292231ea9"
 
 "@csstools/convert-colors@^1.4.0":
   version "1.4.0"
@@ -1078,15 +1168,22 @@
   version "3.5.43"
   resolved "https://registry.yarnpkg.com/@types/d3/-/d3-3.5.43.tgz#e9b4992817e0b6c5efaa7d6e5bb2cee4d73eab58"
 
-"@types/enzyme-adapter-react-16@^1.0.3":
+"@types/enzyme-adapter-react-16@^1.0.5":
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/@types/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.0.5.tgz#1bf30a166f49be69eeda4b81e3f24113c8b4e9d5"
   dependencies:
     "@types/enzyme" "*"
 
-"@types/enzyme@*", "@types/enzyme@^3.1.15":
+"@types/enzyme@*":
   version "3.10.3"
   resolved "https://registry.yarnpkg.com/@types/enzyme/-/enzyme-3.10.3.tgz#02b6c5ac7d0472005944a652e79045e2f6c66804"
+  dependencies:
+    "@types/cheerio" "*"
+    "@types/react" "*"
+
+"@types/enzyme@^3.10.3":
+  version "3.10.4"
+  resolved "https://registry.yarnpkg.com/@types/enzyme/-/enzyme-3.10.4.tgz#dd4961042381a7c0f6637ce25fec3f773ce489dd"
   dependencies:
     "@types/cheerio" "*"
     "@types/react" "*"
@@ -1129,7 +1226,6 @@
 "@types/katex@^0.10.2":
   version "0.10.2"
   resolved "https://registry.yarnpkg.com/@types/katex/-/katex-0.10.2.tgz#322afa83aba5cca4edcea014ebf0be997135dbd9"
-  integrity sha512-QYTNuhuDU22gouVoL5kLmBTguu2rPvtp7wL5U5fTFsQkM1ojfUgxFPMFrqOSUofrdWwnZEmblcobdlLXj1lVOw==
 
 "@types/lodash@^4.14.119":
   version "4.14.138"
@@ -1971,7 +2067,7 @@ babel-preset-jest@^24.9.0:
     "@babel/plugin-syntax-object-rest-spread" "^7.0.0"
     babel-plugin-jest-hoist "^24.9.0"
 
-babel-preset-minify@^0.5.0:
+babel-preset-minify@^0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/babel-preset-minify/-/babel-preset-minify-0.5.1.tgz#25f5d0bce36ec818be80338d0e594106e21eaa9f"
   dependencies:
@@ -2674,6 +2770,12 @@ convert-source-map@1.6.0, convert-source-map@^1.1.0, convert-source-map@^1.4.0:
 convert-source-map@^0.3.3:
   version "0.3.5"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-0.3.5.tgz#f1d802950af7dd2631a1febe0596550c86ab3190"
+
+convert-source-map@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.7.0.tgz#17a2cb882d7f77d3490585e2ce6c524424a3a442"
+  dependencies:
+    safe-buffer "~5.1.1"
 
 cookie-signature@1.0.6:
   version "1.0.6"
@@ -5622,7 +5724,6 @@ jsx-ast-utils@^2.1.0, jsx-ast-utils@^2.2.1:
 katex@0.11.1:
   version "0.11.1"
   resolved "https://registry.yarnpkg.com/katex/-/katex-0.11.1.tgz#df30ca40c565c9df01a466a00d53e079e84ffaa2"
-  integrity sha512-5oANDICCTX0NqYIyAiFCCwjQ7ERu3DQG2JFHLbYOf+fXaMoH8eg/zOq5WSYJsKMi/QebW+Eh3gSM+oss1H/bww==
   dependencies:
     commander "^2.19.0"
 
@@ -7868,14 +7969,14 @@ react-dev-utils@^9.0.4:
     strip-ansi "5.2.0"
     text-table "0.2.0"
 
-react-dom@16.9.0:
-  version "16.9.0"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.9.0.tgz#5e65527a5e26f22ae3701131bcccaee9fb0d3962"
+react-dom@16.12.0:
+  version "16.12.0"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.12.0.tgz#0da4b714b8d13c2038c9396b54a92baea633fe11"
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     prop-types "^15.6.2"
-    scheduler "^0.15.0"
+    scheduler "^0.18.0"
 
 react-error-overlay@^6.0.2:
   version "6.0.2"
@@ -8076,9 +8177,9 @@ react-transition-group@^4.0.0:
     loose-envify "^1.4.0"
     prop-types "^15.6.2"
 
-react@16.9.0:
-  version "16.9.0"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.9.0.tgz#40ba2f9af13bc1a38d75dbf2f4359a5185c4f7aa"
+react@16.12.0:
+  version "16.12.0"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.12.0.tgz#0c0a9c6a142429e3614834d5a778e18aa78a0b83"
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
@@ -8433,15 +8534,15 @@ ripemd160@^2.0.0, ripemd160@^2.0.1:
     hash-base "^3.0.0"
     inherits "^2.0.1"
 
-rollup-plugin-babel-minify@^8.0.0:
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/rollup-plugin-babel-minify/-/rollup-plugin-babel-minify-8.0.0.tgz#15a3f2047597f619f1ed8451ebb680e8d5d62633"
+rollup-plugin-babel-minify@^9.1.1:
+  version "9.1.1"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-babel-minify/-/rollup-plugin-babel-minify-9.1.1.tgz#a08c7c231952e276f234bdbbc5b52072df6d60d9"
   dependencies:
-    "@babel/core" "^7.0.0"
+    "@babel/core" "^7.7.2"
     "@babel/plugin-syntax-dynamic-import" "^7.2.0"
-    "@comandeer/babel-plugin-banner" "^4.0.0"
-    babel-preset-minify "^0.5.0"
-    sourcemap-codec "^1.4.3"
+    "@comandeer/babel-plugin-banner" "^5.0.0"
+    babel-preset-minify "^0.5.1"
+    sourcemap-codec "^1.4.6"
 
 rss-parser@^3.7.2:
   version "3.7.2"
@@ -8551,6 +8652,13 @@ saxes@^3.1.9:
 scheduler@^0.15.0:
   version "0.15.0"
   resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.15.0.tgz#6bfcf80ff850b280fed4aeecc6513bc0b4f17f8e"
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+
+scheduler@^0.18.0:
+  version "0.18.0"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.18.0.tgz#5901ad6659bc1d8f3fdaf36eb7a67b0d6746b1c4"
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
@@ -8857,7 +8965,7 @@ source-map@^0.5.0, source-map@^0.5.3, source-map@^0.5.6:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
 
-sourcemap-codec@^1.4.3:
+sourcemap-codec@^1.4.6:
   version "1.4.6"
   resolved "https://registry.yarnpkg.com/sourcemap-codec/-/sourcemap-codec-1.4.6.tgz#e30a74f0402bad09807640d39e971090a08ce1e9"
 
@@ -9201,16 +9309,15 @@ symbol-tree@^3.2.2:
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"
 
-synapse-react-client@1.12.79:
-  version "1.12.79"
-  resolved "https://registry.yarnpkg.com/synapse-react-client/-/synapse-react-client-1.12.79.tgz#eca9115173164ee3f7b89d0dd7e3a9e42443dd71"
-  integrity sha512-/4QE/EhkPh8UEPfcgAGLLkIzXACyZgaabqn+1vSsjxBL7P5iOln3GTMjHomMj9cliYce8JaCWDf6y5TRQJkeyw==
+synapse-react-client@1.12.85:
+  version "1.12.85"
+  resolved "https://registry.yarnpkg.com/synapse-react-client/-/synapse-react-client-1.12.85.tgz#f870498b774a0629bf7e5ab66e7c9512c44bf39e"
   dependencies:
     "@fortawesome/fontawesome-svg-core" "^1.2.4"
     "@fortawesome/free-solid-svg-icons" "^5.3.1"
     "@fortawesome/react-fontawesome" "^0.1.3"
-    "@types/enzyme" "^3.1.15"
-    "@types/enzyme-adapter-react-16" "^1.0.3"
+    "@types/enzyme" "^3.10.3"
+    "@types/enzyme-adapter-react-16" "^1.0.5"
     "@types/jquery" "^3.3.6"
     "@types/katex" "^0.10.2"
     "@types/lodash" "^4.14.119"
@@ -9247,10 +9354,10 @@ synapse-react-client@1.12.79:
     node-sass "4.12.0"
     plotly.js-basic-dist "^1.47.3"
     raf "^3.4.1"
-    react "16.9.0"
+    react "16.12.0"
     react-app-polyfill "^1.0.1"
     react-bootstrap "^1.0.0-beta.12"
-    react-dom "16.9.0"
+    react-dom "16.12.0"
     react-jsonschema-form "^1.7.0"
     react-mailchimp-subscribe "^2.1.0"
     react-measure "^2.1.2"
@@ -9261,12 +9368,11 @@ synapse-react-client@1.12.79:
     react-test-renderer "^16.4.2"
     react-tooltip "^3.9.2"
     react-transition-group "2.6.0"
-    rollup-plugin-babel-minify "^8.0.0"
+    rollup-plugin-babel-minify "^9.1.1"
     rss-parser "^3.7.2"
     sanitize-html "^1.18.4"
     spark-md5 "^3.0.0"
     sql-parser "^0.5.0"
-    uuid "^3.3.2"
 
 table@^5.2.3:
   version "5.4.6"


### PR DESCRIPTION
This has been an ongoing issue for sometime where the types weren't being respected by typescript. Fixed by importing all the component props from SRC explicitly in the portal-config file. This isn't completely fixed for all the portal components whose types aren't being registered.

There are a few TODOs to remove the ts-ignore comments, once SRC is bumped and pulled into this those won't be needed.