### PR TITLE
fix logout issue

### DIFF
--- a/src/AppInitializer.tsx
+++ b/src/AppInitializer.tsx
@@ -60,12 +60,8 @@ class AppInitializer extends React.Component<Props, AppInitializerState> {
   }
 
   getSession = async () => {
-    const token = await SynapseClient.getSessionTokenFromCookie()
-    if (!token) {
-      this.initAnonymousUserState()
-      return
-    }
     try {
+      const token = await SynapseClient.getSessionTokenFromCookie()
       // try to refresh their session for convenience
       await SynapseClient.putRefreshSessionToken(token)
       this.setState({ token })

--- a/yarn.lock
+++ b/yarn.lock
@@ -10255,9 +10255,9 @@ symbol-tree@^3.2.2:
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"
 
-synapse-react-client@1.13.2:
-  version "1.13.2"
-  resolved "https://registry.yarnpkg.com/synapse-react-client/-/synapse-react-client-1.13.2.tgz#5cfe8b2560dec0c6bde8863027a9e921b667a784"
+synapse-react-client@1.13.3:
+  version "1.13.3"
+  resolved "https://registry.yarnpkg.com/synapse-react-client/-/synapse-react-client-1.13.3.tgz#79a07f367673ed5211bca72a683ab871b74fd176"
   dependencies:
     "@fortawesome/fontawesome-svg-core" "^1.2.4"
     "@fortawesome/free-solid-svg-icons" "^5.3.1"


### PR DESCRIPTION
if there's not token then getSessionTokenFromCookie will fail instead of passing back and empty string, fix this by putting the code segment in the try/catch block