### PR TITLE
Match mocks for BSMN home page, one more fix for PORTALS-1175

### DIFF
--- a/src/configurations/adknowledgeportal/synapseConfigs/projects.ts
+++ b/src/configurations/adknowledgeportal/synapseConfigs/projects.ts
@@ -19,7 +19,12 @@ export const projectCardConfiguration: CardConfiguration = {
     title: 'Name',
     subTitle: 'Key Investigators',
     description: 'Abstract',
-    secondaryLabels: ['Institutions', 'Key Data Contributors', 'Program'],
+    secondaryLabels: [
+      'Institutions',
+      'Key Data Contributors',
+      'Program',
+      'Grant Number',
+    ],
   },
   secondaryLabelLimit: 4,
   titleLinkConfig: {

--- a/src/configurations/bsmn/routesConfig.ts
+++ b/src/configurations/bsmn/routesConfig.ts
@@ -13,9 +13,16 @@ const routes: GenericRoute[] = [
     isNested: false,
     synapseConfigArray: [
       {
-        name: 'StatefulButtonControlWrapper',
-        title: 'EXPLORE PORTAL',
+        name: 'RouteButtonControlWrapper',
+        title: 'EXPLORE DATA',
         props: {
+          customRoutes: [
+            'Projects',
+            'Studies',
+            'Tools',
+            'People',
+            'Publications',
+          ],
           colors: [
             '#E5AE4C',
             '#5BB0B5',
@@ -24,28 +31,6 @@ const routes: GenericRoute[] = [
             '#D4689A',
             '#3C4A63',
             '#407BA0',
-          ],
-          configs: [
-            {
-              name: 'Projects',
-              synapseConfigArray: [projects.homePageSynapseObject],
-            },
-            {
-              name: 'Studies',
-              synapseConfigArray: [studies.homePageSynapseObject],
-            },
-            {
-              name: 'Tools',
-              synapseConfigArray: [tools.homePageSynapseObject],
-            },
-            {
-              name: 'People',
-              synapseConfigArray: [people.homePageSynapseObject],
-            },
-            {
-              name: 'Publications',
-              synapseConfigArray: [publications.homePageSynapseObject],
-            },
           ],
         },
       },

--- a/src/portal-components/RouteButtonControlWrapper.tsx
+++ b/src/portal-components/RouteButtonControlWrapper.tsx
@@ -5,7 +5,7 @@ import { SynapseConfig } from 'types/portal-config'
 import { generateSynapseObject } from '../RouteResolver'
 
 export type RouteButtonControlWrapperProps = {
-  synapseConfig: SynapseConfig
+  synapseConfig?: SynapseConfig
   colors: string[]
   // we have to pass in all the custom routes because unlike the home page the explore buttons configs aren't held in state
   customRoutes: string[]
@@ -45,7 +45,7 @@ const RouteButtonControl: React.FunctionComponent<Props> = ({
   return (
     <React.Fragment>
       <ButtonControl {...buttonControlProps} />
-      {generateSynapseObject(synapseConfig, searchParams)}
+      {synapseConfig && generateSynapseObject(synapseConfig, searchParams)}
     </React.Fragment>
   )
 }


### PR DESCRIPTION
### BSMN
![image](https://user-images.githubusercontent.com/20282487/77367594-b8c7d200-6d17-11ea-82b2-c005c20c9e4a.png) 

^ notice the buttons don't have the bar chart below, they only link out

### AMP-AD
![image](https://user-images.githubusercontent.com/20282487/77367248-fb3cdf00-6d16-11ea-84d8-7cd5076039e0.png)
^Grant Number is now preset on amp-ad project cards