### PR TITLE
update publication secondary label for tool cards

### DIFF
--- a/src/configurations/csbc-pson/synapseConfigs/tools.ts
+++ b/src/configurations/csbc-pson/synapseConfigs/tools.ts
@@ -17,7 +17,7 @@ export const toolsConfiguration: CardConfiguration = {
     title: 'toolName',
     description: 'description',
     secondaryLabels: [
-      'publicationTitle',
+      'publication',
       'inputDataType',
       'outputDataType',
       'softwareLanguage',
@@ -30,7 +30,7 @@ export const toolsConfiguration: CardConfiguration = {
   labelLinkConfig: [
     {
       isMarkdown: true,
-      matchColumnName: 'publicationTitle',
+      matchColumnName: 'publication',
     },
     {
       isMarkdown: false,


### PR DESCRIPTION
Fixing the column name for tool publication links.