### PR TITLE
use markdown formatting for pubmed links; update facet alias

### DIFF
--- a/src/configurations/csbc-pson/facetAliases.ts
+++ b/src/configurations/csbc-pson/facetAliases.ts
@@ -1,4 +1,4 @@
 export default {
   publicationTitle: 'publication',
-  pubMedUrl: 'Pubmed',
+  pubMedLink: 'Pubmed Link',
 }

--- a/src/configurations/csbc-pson/synapseConfigs/publications.ts
+++ b/src/configurations/csbc-pson/synapseConfigs/publications.ts
@@ -16,7 +16,7 @@ export const publicationSchema: GenericCardSchema = {
   title: 'publicationTitle',
   subTitle: 'authors',
   secondaryLabels: [
-    'pubMedUrl',
+    'pubMedLink',
     'journal',
     'publicationYear',
     'theme',
@@ -45,7 +45,7 @@ export const publicationsCardConfiguration: CardConfiguration = {
   labelLinkConfig: [
     {
       isMarkdown: true,
-      matchColumnName: 'pubMedUrl',
+      matchColumnName: 'pubMedLink',
     },
     {
       isMarkdown: false,


### PR DESCRIPTION
Minor fix to the publications config so that PubMed links render as

> PUBMED LINK — [**PMID:28053997**](https://www.ncbi.nlm.nih.gov/pubmed/?term=28053997)

instead of...

> PUBMED — **https://www.ncbi.nlm.nih.gov/pubmed/?term=28053997**