### PR TITLE
CRC researcher portal: only include people who have completed the necessary surveys (testLoc…

### DIFF
--- a/src/configurations/crc-researcher/synapseConfigs/uncategorized.ts
+++ b/src/configurations/crc-researcher/synapseConfigs/uncategorized.ts
@@ -30,7 +30,7 @@ export const baseDataSqlColumns = `symptom,
     dataGroups`
 
 export const baseDataSqlFrom = ` FROM syn22154087 `
-export const baseDataSqlWhere = ` WHERE testLocation in ('lab', 'home', 'noTest') and WorkflowState = `
+export const baseDataSqlWhere = ` WHERE testLocation IN ('lab', 'home', 'noTest') AND dataGroups NOT HAS ('test_user') AND uploadDate > 1595808000000 AND WorkflowState = `
 
 export const baseDataSql = `SELECT ${baseDataSqlColumns} ${baseDataSqlFrom} ${baseDataSqlWhere}  `
 

--- a/src/portal-components/crc-researcher/ParticipantsBarPlot.tsx
+++ b/src/portal-components/crc-researcher/ParticipantsBarPlot.tsx
@@ -122,7 +122,7 @@ function getLayout(
 export function fetchData(
   token: string
 ): Promise<RowSet> {
-  const sql = 'SELECT WorkflowState as "x", count(*) as "count" FROM syn22154087 GROUP BY WorkflowState'
+  const sql = 'SELECT WorkflowState as "x", count(*) as "count" FROM syn22154087 WHERE dataGroups NOT HAS (\'test_user\') AND uploadDate > 1595808000000 AND testLocation IN (\'lab\', \'home\', \'noTest\') GROUP BY WorkflowState'
   
   const queryRequest: QueryBundleRequest = {
     concreteType: 'org.sagebionetworks.repo.model.table.QueryBundleRequest',

--- a/src/portal-components/crc-researcher/StatusLineChart.tsx
+++ b/src/portal-components/crc-researcher/StatusLineChart.tsx
@@ -168,13 +168,15 @@ const StatusLineChart: FunctionComponent<StatusLineChartProps> = ({
   const [plotData, setPlotData] = useState<PlotData | null>(null)
 
   const samplesCollectedSql =
-    'SELECT uploadDate as "x", count(distinct(recordId)) as "y" FROM syn22154087 WHERE uploadDate IS NOT NULL GROUP BY uploadDate ORDER BY uploadDate'
+    'SELECT uploadDate as "x", count(distinct(recordId)) as "y" FROM syn22154087 WHERE uploadDate IS NOT NULL AND dataGroups NOT HAS (\'test_user\') AND uploadDate > 1595808000000 AND testLocation IN (\'lab\', \'home\', \'noTest\') GROUP BY uploadDate ORDER BY uploadDate'
   const inviteSentSql =
-    'SELECT inviteSentOn as "x", count(distinct(recordId)) as "y" FROM syn22154087 WHERE inviteSentOn IS NOT NULL GROUP BY inviteSentOn ORDER BY inviteSentOn'
+    'SELECT inviteSentOn as "x", count(distinct(recordId)) as "y" FROM syn22154087 WHERE inviteSentOn IS NOT NULL AND dataGroups NOT HAS (\'test_user\') AND uploadDate > 1595808000000 AND testLocation IN (\'lab\', \'home\', \'noTest\') GROUP BY inviteSentOn ORDER BY inviteSentOn'
   const appointmentScheduledSql =
-    'SELECT scheduledLabDrawOn as "x", count(distinct(recordId)) as "y" FROM syn22154087 WHERE scheduledLabDrawOn IS NOT NULL GROUP BY scheduledLabDrawOn ORDER BY scheduledLabDrawOn'
+    'SELECT scheduledLabDrawOn as "x", count(distinct(recordId)) as "y" FROM syn22154087 WHERE scheduledLabDrawOn IS NOT NULL AND dataGroups NOT HAS (\'test_user\') AND uploadDate > 1595808000000 GROUP BY scheduledLabDrawOn ORDER BY scheduledLabDrawOn'
+
+  // NOTE: dataGroups is a String column in syn22028237 (rather than a multi-value StringList type column), so we're using a LIKE clause in this one to filter out test users instead of HAS.
   const appointmentMadeSql =
-    'SELECT uploadDate as "x", count(distinct(recordId)) as "y" FROM syn22028237 where `metadata.type` =  \'appointment\' AND uploadDate IS NOT NULL GROUP BY uploadDate'
+    'SELECT uploadDate as "x", count(distinct(recordId)) as "y" FROM syn22028237 where `metadata.type` =  \'appointment\' AND uploadDate IS NOT NULL AND dataGroups NOT LIKE \'%test_user%\' GROUP BY uploadDate'
 
   useEffect(() => {
     const collectedData = fetchData(token!, samplesCollectedSql, 'syn22154087')


### PR DESCRIPTION
…ation is set), and filter out test users (using dataGroups, and uploadDate as the stopgap until synapse is updated)