### PR TITLE
PORTALS-1596: Add deploy_date.txt file to ./build directory

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -67,6 +67,9 @@ User-agent: *
 Allow: /
 EOL
   aws s3 cp --cache-control max-age=3000 ./robots.txt $S3_PRODUCTION_BUCK_LOCATION
+  date +"%D %T" > ./deploy_date.txt
+  aws s3 cp --cache-control max-age=3000 ./deploy_date.txt $S3_PRODUCTION_BUCK_LOCATION
+
 elif [ "$1" = "push-staging" ]; then
   # sync current with staging
   yarn && yarn build
@@ -76,6 +79,7 @@ cat > ./build/robots.txt <<EOL
 User-agent: * 
 Disallow: /
 EOL
+  date +"%D %T" > ./build/deploy_date.txt
   aws s3 sync --delete --cache-control max-age=0 ./build $S3_STAGING_BUCKET_LOCATION
 fi
 echo 'Success - finished!'


### PR DESCRIPTION
[PORTALS-1596]
In ./build for staging, pushed along with other files
In . for prod, pushed to root of bucket (should overwrite the file deployed by the S3 sync from staging)

[PORTALS-1596]: https://sagebionetworks.jira.com/browse/PORTALS-1596