### PR TITLE
PORTALS-1575

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "react-spinners": "^0.8.3",
     "sass": "^1.5.1",
     "source-map-explorer": "^1.6.0",
-    "synapse-react-client": "1.15.13",
+    "synapse-react-client": "1.15.14",
     "typescript": "3.7.4",
     "plotly.js-basic-dist": "^1.47.3"
   },

--- a/src/configurations/psychencode/resources.ts
+++ b/src/configurations/psychencode/resources.ts
@@ -1,0 +1,7 @@
+// Portal owners can change the versions of the resources by modifying the
+// version of the entity used in the sql below
+export const studiesSql = `SELECT * FROM syn21783965`
+export const dataSql = 'SELECT * FROM syn20821313'
+export const peopleSql = 'SELECT * FROM syn22096112'
+export const grantSql = 'SELECT * FROM syn22096130'
+export const publicationSql = 'SELECT * FROM syn22095937'

--- a/src/configurations/psychencode/routesConfig.ts
+++ b/src/configurations/psychencode/routesConfig.ts
@@ -1,13 +1,12 @@
 import { GenericRoute } from 'types/portal-config'
 import { studies, studyDetailPage } from './synapseConfigs/studies'
-import { facetAliases } from './synapseConfigs/commonProps'
-import { publicationSql, publications } from './synapseConfigs/publications'
+import { publications } from './synapseConfigs/publications'
 import routeButtonControlWrapperProps from './routeButtonControlWrapperProps'
-import { publicationsCardConfiguration } from './synapseConfigs/publications'
 import { grants, grantsDetailPage } from './synapseConfigs/grants'
 import { people } from './synapseConfigs/people'
 import { data } from './synapseConfigs/data'
 import loadingScreen from './loadingScreen'
+import { peopleSql } from './resources'
 
 const routes: GenericRoute[] = [
   {
@@ -48,7 +47,7 @@ const routes: GenericRoute[] = [
         outsideContainerClassName: 'home home__odd',
         centerTitle: true,
         props: {
-          sql: 'SELECT * FROM syn22096112 where feature=true',
+          sql: `${peopleSql} where feature=true`,
           rgbIndex: 0,
           count: 3,
           loadingScreen,
@@ -143,20 +142,6 @@ const routes: GenericRoute[] = [
             props: {
               ...routeButtonControlWrapperProps,
               synapseConfig: publications,
-            },
-          },
-        ],
-        programmaticRouteConfig: [
-          {
-            name: 'CardContainerLogic',
-            isOutsideContainer: true,
-            props: {
-              isHeader: true,
-              backgroundColor: '#407ba0',
-              facetAliases,
-              ...publicationsCardConfiguration,
-              secondaryLabelLimit: Infinity,
-              sql: publicationSql,
             },
           },
         ],

--- a/src/configurations/psychencode/synapseConfigs/commonProps.ts
+++ b/src/configurations/psychencode/synapseConfigs/commonProps.ts
@@ -1,1 +1,0 @@
-export const facetAliases = {}

--- a/src/configurations/psychencode/synapseConfigs/data.ts
+++ b/src/configurations/psychencode/synapseConfigs/data.ts
@@ -1,8 +1,7 @@
 import { SynapseConfig } from 'types/portal-config'
 import loadingScreen from '../loadingScreen'
+import { dataSql } from '../resources'
 
-const sql = 'SELECT * FROM syn20821313'
-export const dataSql = sql
 export const dataEntityId = 'syn20821313'
 
 const facetAliases = {
@@ -17,7 +16,7 @@ export const data: SynapseConfig = {
   props: {
     rgbIndex,
     unitDescription,
-    sql,
+    sql: dataSql,
     tableConfiguration: {
       showAccessColumn: true,
       columnLinks: [

--- a/src/configurations/psychencode/synapseConfigs/grants.ts
+++ b/src/configurations/psychencode/synapseConfigs/grants.ts
@@ -11,8 +11,8 @@ import { studyDetailPageProps } from './studies'
 import { publicationDetailPageProps } from './publications'
 import { peopleDetailPageProps } from './people'
 import { Project } from 'synapse-react-client/dist/assets/themed_icons/Project'
-export const grantSql = 'SELECT * FROM syn22096130'
-const sql = grantSql
+import { grantSql } from '../resources'
+
 const rgbIndex = 2
 
 export const grantSchema: GenericCardSchema = {
@@ -45,7 +45,7 @@ export const grants: SynapseConfig = {
   props: {
     rgbIndex,
     cardConfiguration: grantCardConfiguration,
-    sql,
+    sql: grantSql,
     shouldDeepLink: true,
     hideDownload: true,
     name: 'Grants',
@@ -74,7 +74,7 @@ export const grants: SynapseConfig = {
 }
 
 const details: DetailsPageProps = {
-  sql,
+  sql: grantSql,
   sqlOperator: 'LIKE',
   synapseConfigArray: [
     {
@@ -101,7 +101,7 @@ const details: DetailsPageProps = {
     {
       name: 'CardContainerLogic',
       props: {
-        sql,
+        sql: grantSql,
         ...grantCardConfiguration,
       },
       columnName: 'relatedGrants',
@@ -123,7 +123,7 @@ export const grantsDetailPage: SynapseConfigArray = [
       titleLinkConfig: undefined,
       genericCardSchema: grantSchema,
       rgbIndex,
-      sql,
+      sql: grantSql,
     },
   },
   {

--- a/src/configurations/psychencode/synapseConfigs/people.ts
+++ b/src/configurations/psychencode/synapseConfigs/people.ts
@@ -1,6 +1,7 @@
 import { SynapseConfig } from 'types/portal-config'
 import { SynapseConstants } from 'synapse-react-client'
 import loadingScreen from '../loadingScreen'
+import { peopleSql } from '../resources'
 
 const name = 'PEOPLE'
 const sql = 'SELECT * FROM syn22096112'
@@ -9,7 +10,7 @@ const rgbIndex = 4
 export const people: SynapseConfig = {
   name: 'QueryWrapperPlotNav',
   props: {
-    sql,
+    sql: peopleSql,
     cardConfiguration: {
       type: SynapseConstants.MEDIUM_USER_CARD,
     },

--- a/src/configurations/psychencode/synapseConfigs/publications.ts
+++ b/src/configurations/psychencode/synapseConfigs/publications.ts
@@ -2,10 +2,8 @@ import { SynapseConstants } from 'synapse-react-client'
 import { SynapseConfig } from 'types/portal-config'
 import loadingScreen from '../loadingScreen'
 import { GenericCardSchema } from 'synapse-react-client/dist/containers/GenericCard'
-import { facetAliases } from './commonProps'
 import { CardConfiguration } from 'synapse-react-client/dist/containers/CardContainerLogic'
-export const publicationSql = 'SELECT * FROM syn22095937'
-const sql = publicationSql
+const sql = 'SELECT * FROM syn22095937'
 const rgbIndex = 1
 
 export const publicationSchema: GenericCardSchema = {
@@ -61,7 +59,6 @@ export const publications: SynapseConfig = {
     },
     facetsToPlot: ['study', 'grants'],
     name: 'Publications',
-    facetAliases,
   },
 }
 

--- a/src/configurations/psychencode/synapseConfigs/publications.ts
+++ b/src/configurations/psychencode/synapseConfigs/publications.ts
@@ -3,7 +3,7 @@ import { SynapseConfig } from 'types/portal-config'
 import loadingScreen from '../loadingScreen'
 import { GenericCardSchema } from 'synapse-react-client/dist/containers/GenericCard'
 import { CardConfiguration } from 'synapse-react-client/dist/containers/CardContainerLogic'
-const sql = 'SELECT * FROM syn22095937'
+import { publicationSql } from '../resources'
 const rgbIndex = 1
 
 export const publicationSchema: GenericCardSchema = {
@@ -25,7 +25,7 @@ export const publications: SynapseConfig = {
   name: 'QueryWrapperPlotNav',
   props: {
     rgbIndex,
-    sql,
+    sql: publicationSql,
     shouldDeepLink: true,
     hideDownload: true,
     cardConfiguration: publicationsCardConfiguration,
@@ -63,6 +63,6 @@ export const publications: SynapseConfig = {
 }
 
 export const publicationDetailPageProps = {
-  sql,
+  sql: publicationSql,
   ...publicationsCardConfiguration,
 }

--- a/src/configurations/psychencode/synapseConfigs/studies.ts
+++ b/src/configurations/psychencode/synapseConfigs/studies.ts
@@ -7,8 +7,6 @@ import { DetailsPageProps } from 'types/portal-util-types'
 import { studiesSql, dataSql } from '../resources'
 import { parseEntityIdFromSqlStatement } from 'synapse-react-client/dist/utils/functions/sqlFunctions'
 import { publicationDetailPageProps } from './publications'
-export const studiesEntityId = 'syn21783965'
-const sql = `SELECT * FROM syn21783965`
 const rgbIndex = 1
 
 export const studySchema: GenericCardSchema = {
@@ -88,7 +86,7 @@ export const studies: SynapseConfig = {
 }
 
 export const details: DetailsPageProps = {
-  sql,
+  sql: studiesSql,
   synapseConfigArray: [
     {
       name: 'Markdown',
@@ -156,7 +154,7 @@ export const details: DetailsPageProps = {
       title: 'Related Studies',
       props: {
         ...studyCardConfiguration,
-        sql,
+        sql: studiesSql,
       },
       columnName: 'relatedStudies',
       tableSqlKeys: ['study'],
@@ -185,7 +183,7 @@ export const studyDetailPage: SynapseConfigArray = [
       titleLinkConfig: undefined,
       rgbIndex,
       genericCardSchema: studySchema,
-      sql,
+      sql: studiesSql,
     },
   },
   {
@@ -195,6 +193,6 @@ export const studyDetailPage: SynapseConfigArray = [
 ]
 
 export const studyDetailPageProps = {
-  sql,
+  sql: studiesSql,
   ...studyCardConfiguration,
 }

--- a/src/configurations/psychencode/synapseConfigs/studies.ts
+++ b/src/configurations/psychencode/synapseConfigs/studies.ts
@@ -1,15 +1,14 @@
 import { SynapseConstants } from 'synapse-react-client'
 import loadingScreen from '../loadingScreen'
-import { facetAliases } from './commonProps'
 import { GenericCardSchema } from 'synapse-react-client/dist/containers/GenericCard'
 import { CardConfiguration } from 'synapse-react-client/dist/containers/CardContainerLogic'
 import { SynapseConfig, SynapseConfigArray } from 'types/portal-config'
 import { DetailsPageProps } from 'types/portal-util-types'
-import { dataSql, dataEntityId } from './data'
+import { studiesSql, dataSql } from '../resources'
+import { parseEntityIdFromSqlStatement } from 'synapse-react-client/dist/utils/functions/sqlFunctions'
 import { publicationDetailPageProps } from './publications'
-export const studiesSql = `SELECT * FROM syn21783965`
 export const studiesEntityId = 'syn21783965'
-const sql = studiesSql
+const sql = `SELECT * FROM syn21783965`
 const rgbIndex = 1
 
 export const studySchema: GenericCardSchema = {
@@ -52,12 +51,11 @@ export const studies: SynapseConfig = {
   name: 'QueryWrapperPlotNav',
   props: {
     rgbIndex,
-    sql,
+    sql: studiesSql,
     loadingScreen,
     shouldDeepLink: true,
     cardConfiguration: studyCardConfiguration,
     name: 'Studies',
-    facetAliases,
     searchConfiguration: {
       searchable: [
         {
@@ -120,7 +118,9 @@ export const details: DetailsPageProps = {
     {
       name: 'StandaloneQueryWrapper',
       props: {
-        sql: `SELECT id, dataSubtype, dataType, assay FROM ${dataEntityId} WHERE "dataSubtype" = 'metadata'`,
+        sql: `SELECT id, dataSubtype, dataType, assay FROM ${parseEntityIdFromSqlStatement(
+          dataSql,
+        )} WHERE "dataSubtype" = 'metadata'`,
         facetAliases: {
           id: 'File Name',
           dataSubtype: 'Metadata Type',
@@ -184,7 +184,6 @@ export const studyDetailPage: SynapseConfigArray = [
       ...studyCardConfiguration,
       titleLinkConfig: undefined,
       rgbIndex,
-      facetAliases,
       genericCardSchema: studySchema,
       sql,
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -12189,10 +12189,10 @@ symbol-tree@^3.2.2:
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"
   integrity sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==
 
-synapse-react-client@1.15.13:
-  version "1.15.13"
-  resolved "https://registry.yarnpkg.com/synapse-react-client/-/synapse-react-client-1.15.13.tgz#f1a1b5d0b5a1ddde886b6a4d2bfbb818533e1cfc"
-  integrity sha512-sY73ZckT3T2/sUeGwv7HwVJvT/+YeXzYPOzn7NJTKc6Gm1Dqbko6oGPMf01Y5nv8ypcUGEIc25TgVjCU8UsKLg==
+synapse-react-client@1.15.14:
+  version "1.15.14"
+  resolved "https://registry.yarnpkg.com/synapse-react-client/-/synapse-react-client-1.15.14.tgz#22ce01f0136458a9941d402976ecde6547515799"
+  integrity sha512-iI2GO1PmLrldtQbfmB+lkJJTnQWz5S22rszYAVTTIDIBCT2i/95K28X+hDE1uLBMGBZFTpsk9K4G4b1JzNWYOA==
   dependencies:
     "@fortawesome/fontawesome-free" "^5.13.0"
     "@fortawesome/fontawesome-svg-core" "^1.2.4"


### PR DESCRIPTION
- restructure psychencode to contain top level file `resources.ts` with table identifiers, allowing portal owners to more easily version the portal by update just that file
- Bump src for bug fixes: fix sql parser encountering versioned synId, fix dataset cards for NF, news feed updates