### PR TITLE
Proposal to simplify routing

### DIFF
--- a/src/Navbar.tsx
+++ b/src/Navbar.tsx
@@ -46,7 +46,7 @@ class Navbar extends React.Component {
   ]
 
   // given the hash, decide if the link should have a bottom border
-  getBorder = (name: string) => {
+  getBorder = (name: string = '') => {
     if (name === '') {
       // special case the home page
       return
@@ -180,10 +180,11 @@ class Navbar extends React.Component {
               routesConfig
                 .slice()
                 .reverse()
-                .filter((el) => el.to !== '/')
+                .filter((el) => el.to !== '')
                 .map((el) => {
-                  let displayName = el.displayName ? el.displayName : el.name
-                  const icon = (
+                  const topLevelTo = el.link ?? el.to
+                  let displayName = el.displayName ? el.displayName : topLevelTo
+                  const icon = el.icon && (
                     <img style={{ padding: '0px 4px' }} src={el.icon} />
                   )
                   if (el.hideRouteFromNavbar) {
@@ -193,23 +194,24 @@ class Navbar extends React.Component {
                     return (
                       <>
                         {el.routes.map((route) => {
+                          const { to, link } = route
                           // Add anchors to the DOM for a crawler to find.  This is an attempt to fix an issue where all routes are Excluded from the index.
                           if (route.hideRouteFromNavbar) {
                             return false
                           }
-                          const routeDisplayName =
-                            route.displayName || route.name
+                          const routeDisplayName = route.displayName ?? to
+                          const linkDisplay = link ?? `/${topLevelTo}/${to}`
                           return (
                             <a
-                              key={`${route.name}-seo-anchor`}
+                              key={`${to}-seo-anchor`}
                               className="crawler-link"
-                              href={`${route.to}`}
+                              href={linkDisplay}
                             >
                               {routeDisplayName}
                             </a>
                           )
                         })}
-                        <Dropdown className={this.getBorder(el.name)}>
+                        <Dropdown className={this.getBorder(topLevelTo)}>
                           <Dropdown.Toggle
                             variant="light"
                             id={displayName}
@@ -219,16 +221,17 @@ class Navbar extends React.Component {
                           </Dropdown.Toggle>
                           <Dropdown.Menu className="portal-nav-menu">
                             {el.routes.map((route) => {
+                              const { to, link } = route
                               if (route.hideRouteFromNavbar) {
                                 return false
                               }
-                              const routeDisplayName =
-                                route.displayName || route.name
+                              const routeDisplayName = route.displayName ?? to!
+                              const linkDisplay = link ?? `/${topLevelTo}/${to}`
                               return (
-                                <Dropdown.Item key={route.name} as="li">
+                                <Dropdown.Item key={to} as="li">
                                   <NavLink
                                     className="dropdown-item SRC-primary-background-color-hover SRC-nested-color"
-                                    to={route.to!}
+                                    to={linkDisplay}
                                     text={routeDisplayName}
                                   />
                                 </Dropdown.Item>
@@ -239,31 +242,18 @@ class Navbar extends React.Component {
                       </>
                     )
                   }
-                  // treat it as standard anchor tag
-                  if (el.synapseConfigArray!.length === 0) {
-                    return (
-                      <NavLink
-                        key={el.name}
-                        className={`nav-button nav-button-container center-content ${this.getBorder(
-                          el.name,
-                        )}`}
-                        to={el.to!}
-                        text={
-                          <>
-                            {icon} {displayName}
-                          </>
-                        }
-                      />
-                    )
-                  }
                   return (
                     <NavLink
-                      key={el.name}
+                      key={topLevelTo}
                       className={`nav-button nav-button-container center-content ${this.getBorder(
-                        el.name,
+                        topLevelTo,
                       )}`}
-                      to={el.to!}
-                      text={displayName}
+                      to={`/${topLevelTo!}`}
+                      text={
+                        <>
+                          {icon} {displayName}
+                        </>
+                      }
                     />
                   )
                 })

--- a/src/RouteResolver.tsx
+++ b/src/RouteResolver.tsx
@@ -24,6 +24,10 @@ export const getRouteFromParams = (pathname: string) => {
   if (split[split.length - 1].match(/index\.html?/gim)) {
     // remove index.html
     split.pop()
+    if (split.length === 0) {
+      // need to have at least 1 items
+      split.push('')
+    }
   }
   let route = routesConfig.find((el) => split[0] === el.to)!
   // search the route configs for the pathname

--- a/src/RouteResolver.tsx
+++ b/src/RouteResolver.tsx
@@ -29,7 +29,7 @@ export const getRouteFromParams = (pathname: string) => {
       split.push('')
     }
   }
-  let route = routesConfig.find((el) => split[1] === el.name)!
+  let route = routesConfig.find((el) => split[1] === el.to)!
   // search the route configs for the pathname
   for (let i = 1; i < split.length; i += 1) {
     if (!route) {

--- a/src/RouteResolver.tsx
+++ b/src/RouteResolver.tsx
@@ -24,12 +24,8 @@ export const getRouteFromParams = (pathname: string) => {
   if (split[split.length - 1].match(/index\.html?/gim)) {
     // remove index.html
     split.pop()
-    if (split.length == 1) {
-      // need to have at least 2 items
-      split.push('')
-    }
   }
-  let route = routesConfig.find((el) => split[1] === el.to)!
+  let route = routesConfig.find((el) => split[0] === el.to)!
   // search the route configs for the pathname
   for (let i = 1; i < split.length; i += 1) {
     if (!route) {

--- a/src/RouteResolver.tsx
+++ b/src/RouteResolver.tsx
@@ -18,16 +18,16 @@ function fail(message: string): never {
 */
 export const getRouteFromParams = (pathname: string) => {
   // e.g. pathname = /Explore/Programs
-  // e.g. split = '', 'Explore', 'Programs
-  const split = pathname.split('/')
-  let route = routesConfig.find((el) => split[1] === el.name)!
+  const split = pathname.split('/').slice(1)
+  // e.g. split = 'Explore', 'Programs
+  let route = routesConfig.find((el) => split[0] === el.to)!
   // search the route configs for the pathname
-  for (let i = 2; i < split.length; i += 1) {
+  for (let i = 1; i < split.length; i += 1) {
     if (!route) {
       return fail(`Error: url at ${pathname} has no route mapping`)
     }
     if (route.isNested) {
-      route = route.routes.find((el) => split[i] === el.name)!
+      route = route.routes.find((el) => el.to!.includes(split[i]))!
     } else {
       fail(`Route at ${pathname} has no SynapseConfigArray mapping`)
     }
@@ -106,7 +106,7 @@ const RouteResolver: React.FunctionComponent<RouteComponentProps> = ({
   }
 
   // get page title and set document title to it
-  const pageName: string = route.displayName ? route.displayName : route.name
+  const pageName: string = route.displayName ? route.displayName : route.to!
   const newTitle: string = `${docTitleConfig.name} - ${pageName}`
   if (document.title !== newTitle) {
     document.title = newTitle

--- a/src/_App.scss
+++ b/src/_App.scss
@@ -207,12 +207,12 @@ body {
   padding: 0px 25px !important;
   margin: 0px !important;
   min-width: 100px;
-  // max-width: 150px;
   white-space: normal;
   @extend %fillerBorder;
 }
 
-.top-nav-button, a.top-nav-button {
+.top-nav-button,
+a.top-nav-button {
   text-transform: uppercase;
   font-weight: bold;
   height: -webkit-fill-available;
@@ -565,5 +565,3 @@ div.SRC-marginBottomTen {
     }
   }
 }
-
-

--- a/src/_App.scss
+++ b/src/_App.scss
@@ -207,7 +207,7 @@ body {
   padding: 0px 25px !important;
   margin: 0px !important;
   min-width: 100px;
-  max-width: 150px;
+  // max-width: 150px;
   white-space: normal;
   @extend %fillerBorder;
 }

--- a/src/configurations/adknowledgeportal/routesConfig.ts
+++ b/src/configurations/adknowledgeportal/routesConfig.ts
@@ -26,8 +26,7 @@ import { projectsSql, studiesSql } from './resources'
 
 const routes: GenericRoute[] = [
   {
-    name: '',
-    to: '/',
+    to: '',
     isNested: false,
     synapseConfigArray: [
       {
@@ -94,13 +93,12 @@ const routes: GenericRoute[] = [
     ],
   },
   {
-    name: 'Explore',
+    to: 'Explore',
     isNested: true,
     routes: [
       {
-        name: 'Programs',
         isNested: true,
-        to: '/Explore/Programs',
+        to: 'Programs',
         synapseConfigArray: [
           {
             name: 'RouteButtonControlWrapper',
@@ -119,9 +117,8 @@ const routes: GenericRoute[] = [
         ],
         routes: [
           {
-            name: 'DetailsPage',
             isNested: false,
-            to: '/Explore/Programs/DetailsPage',
+            to: 'DetailsPage',
             synapseConfigArray: [
               {
                 name: 'CardContainerLogic',
@@ -152,13 +149,11 @@ const routes: GenericRoute[] = [
         ],
       },
       {
-        name: 'Projects',
         isNested: true,
-        to: '/Explore/Projects',
+        to: 'Projects',
         routes: [
           {
-            name: 'DetailsPage',
-            to: 'Explore/Projects/DetailsPage',
+            to: 'DetailsPage',
             isNested: false,
             synapseConfigArray: [
               {
@@ -205,9 +200,8 @@ const routes: GenericRoute[] = [
         ],
       },
       {
-        name: 'Studies',
         isNested: true,
-        to: '/Explore/Studies',
+        to: 'Studies',
         synapseConfigArray: [
           {
             name: 'RouteButtonControlWrapper',
@@ -220,17 +214,15 @@ const routes: GenericRoute[] = [
         ],
         routes: [
           {
-            name: 'DetailsPage',
-            to: 'Explore/Studies/DetailsPage',
+            to: 'DetailsPage',
             isNested: false,
             synapseConfigArray: studiesProgrammaticRouteConfig,
           },
         ],
       },
       {
-        name: 'Data',
         isNested: false,
-        to: '/Explore/Data',
+        to: 'Data',
         synapseConfigArray: [
           {
             name: 'RouteButtonControlWrapper',
@@ -243,9 +235,8 @@ const routes: GenericRoute[] = [
         ],
       },
       {
-        name: 'Publications',
         isNested: false,
-        to: '/Explore/Publications',
+        to: 'Publications',
         synapseConfigArray: [
           {
             name: 'RouteButtonControlWrapper',
@@ -258,9 +249,8 @@ const routes: GenericRoute[] = [
         ],
       },
       {
-        name: 'People',
         isNested: false,
-        to: '/Explore/People',
+        to: 'People',
         synapseConfigArray: [
           {
             name: 'RouteButtonControlWrapper',
@@ -273,9 +263,8 @@ const routes: GenericRoute[] = [
         ],
       },
       {
-        name: 'Experimental Tools',
         isNested: false,
-        to: '/Explore/Experimental Tools',
+        to: 'Experimental Tools',
         synapseConfigArray: [
           {
             name: 'RouteButtonControlWrapper',
@@ -288,9 +277,8 @@ const routes: GenericRoute[] = [
         ],
       },
       {
-        name: 'Computational Tools',
         isNested: false,
-        to: '/Explore/Computational Tools',
+        to: 'Computational Tools',
         synapseConfigArray: [
           {
             name: 'RouteButtonControlWrapper',
@@ -303,9 +291,8 @@ const routes: GenericRoute[] = [
         ],
       },
       {
-        name: 'Results',
         isNested: false,
-        to: '/Explore/Results',
+        to: 'Results',
         synapseConfigArray: [
           {
             name: 'RouteButtonControlWrapper',
@@ -320,10 +307,8 @@ const routes: GenericRoute[] = [
     ],
   },
   {
-    name: 'Analytical Workspace',
-    displayName: 'Analytical Workspace',
     isNested: false,
-    to: '/Analytical Workspace',
+    to: 'Analytical Workspace',
     synapseConfigArray: [
       {
         name: 'Markdown',
@@ -335,15 +320,14 @@ const routes: GenericRoute[] = [
     ],
   },
   {
-    name: 'DataAccess',
+    to: 'DataAccess',
     displayName: 'Data Access',
     isNested: true,
     routes: [
       {
-        name: 'Instructions',
         displayName: 'Getting Access to Data',
         isNested: false,
-        to: '/DataAccess/Instructions',
+        to: 'Instructions',
         synapseConfigArray: [
           {
             name: 'Markdown',
@@ -356,8 +340,7 @@ const routes: GenericRoute[] = [
         ],
       },
       {
-        name: 'DataUseCertificates',
-        to: '/DataAccess/DataUseCertificates',
+        to: 'DataUseCertificates',
         displayName: 'Data Use Certificates',
         isNested: false,
         synapseConfigArray: [
@@ -372,10 +355,9 @@ const routes: GenericRoute[] = [
         ],
       },
       {
-        name: 'AcknowledgementStatements',
         displayName: 'Acknowledging Data Use',
         isNested: false,
-        to: '/DataAccess/AcknowledgementStatements',
+        to: 'AcknowledgementStatements',
         synapseConfigArray: [
           {
             name: 'Markdown',
@@ -388,10 +370,9 @@ const routes: GenericRoute[] = [
         ],
       },
       {
-        name: 'DataUseProposals',
         displayName: 'Data Use Proposals',
         isNested: false,
-        to: '/DataAccess/DataUseProposals',
+        to: 'DataUseProposals',
         synapseConfigArray: [
           {
             name: 'Markdown',
@@ -407,9 +388,8 @@ const routes: GenericRoute[] = [
   },
   // Uncomment to expose Contribute route (once research team is monitoring submissions)
   {
-    name: 'Contribute',
     isNested: false,
-    to: '/Contribute',
+    to: 'Contribute',
     synapseConfigArray: [
       {
         name: 'Markdown',
@@ -452,9 +432,8 @@ const routes: GenericRoute[] = [
     ],
   },
   {
-    name: 'About',
     isNested: false,
-    to: '/About',
+    to: 'About',
     hideRouteFromNavbar: true,
     synapseConfigArray: [
       {
@@ -468,21 +447,18 @@ const routes: GenericRoute[] = [
     ],
   },
   {
-    name: 'News',
-    to: '/News',
+    to: 'News',
     isNested: false,
     synapseConfigArray: news,
   },
   {
-    name: 'Help',
-    to: '/Help',
+    to: 'Help',
     isNested: true,
     synapseConfigArray: news,
     routes: [
       {
         isNested: false,
-        name: 'FAQ',
-        to: '/Help/FAQ',
+        to: 'FAQ',
         synapseConfigArray: [
           {
             name: 'Markdown',
@@ -496,14 +472,16 @@ const routes: GenericRoute[] = [
       },
       {
         isNested: false,
-        name: 'Forum',
-        to: 'https://www.synapse.org/#!Synapse:syn2580853/discussion/default',
+        displayName: 'Forum',
+        to: undefined,
+        link: 'https://www.synapse.org/#!Synapse:syn2580853/discussion/default',
         synapseConfigArray: [],
       },
       {
         isNested: false,
-        name: 'ContactUs',
-        to: 'mailto:ampadportal@sagebionetworks.org',
+        displayName: 'ContactUs',
+        to: undefined,
+        link: 'mailto:ampadportal@sagebionetworks.org',
         synapseConfigArray: [],
       },
     ],

--- a/src/configurations/bsmn/routesConfig.ts
+++ b/src/configurations/bsmn/routesConfig.ts
@@ -16,8 +16,7 @@ import people from './synapseConfigs/people'
 
 const routes: GenericRoute[] = [
   {
-    name: '',
-    to: '/',
+    to: '',
     isNested: false,
     synapseConfigArray: [
       {
@@ -43,12 +42,11 @@ const routes: GenericRoute[] = [
     ],
   },
   {
-    name: 'Explore',
+    to: 'Explore',
     isNested: true,
     routes: [
       {
-        name: 'Projects',
-        to: '/Explore/Projects',
+        to: 'Projects',
         isNested: true,
         synapseConfigArray: [
           {
@@ -62,9 +60,8 @@ const routes: GenericRoute[] = [
         ],
         routes: [
           {
-            name: 'DetailsPage',
             isNested: false,
-            to: 'Explore/Projects/DetailsPage',
+            to: 'DetailsPage',
             synapseConfigArray: [
               {
                 name: 'CardContainerLogic',
@@ -87,8 +84,7 @@ const routes: GenericRoute[] = [
         ],
       },
       {
-        name: 'Studies',
-        to: '/Explore/Studies',
+        to: 'Studies',
         isNested: true,
         synapseConfigArray: [
           {
@@ -102,8 +98,7 @@ const routes: GenericRoute[] = [
         ],
         routes: [
           {
-            name: 'DetailsPage',
-            to: '/Explore/Studies/DetailsPage',
+            to: 'DetailsPage',
             isNested: false,
             synapseConfigArray: [
               {
@@ -128,8 +123,7 @@ const routes: GenericRoute[] = [
         ],
       },
       {
-        name: 'Tools',
-        to: '/Explore/Tools',
+        to: 'Tools',
         isNested: false,
         synapseConfigArray: [
           {
@@ -143,8 +137,7 @@ const routes: GenericRoute[] = [
         ],
       },
       {
-        name: 'People',
-        to: '/Explore/People',
+        to: 'People',
         isNested: false,
         synapseConfigArray: [
           {
@@ -158,8 +151,7 @@ const routes: GenericRoute[] = [
         ],
       },
       {
-        name: 'Publications',
-        to: '/Explore/Publications',
+        to: 'Publications',
         isNested: false,
         synapseConfigArray: [
           {
@@ -175,8 +167,7 @@ const routes: GenericRoute[] = [
     ],
   },
   {
-    name: 'About',
-    to: '/About',
+    to: 'About',
     isNested: false,
     synapseConfigArray: [
       {

--- a/src/configurations/cancercomplexity/routesConfig.ts
+++ b/src/configurations/cancercomplexity/routesConfig.ts
@@ -23,8 +23,7 @@ import facetAliases from './facetAliases'
 
 const routes: GenericRoute[] = [
   {
-    name: '',
-    to: '/',
+    to: '',
     isNested: false,
     synapseConfigArray: [
       {
@@ -148,12 +147,11 @@ const routes: GenericRoute[] = [
     ],
   },
   {
-    name: 'Explore',
+    to: 'Explore',
     isNested: true,
     routes: [
       {
-        name: 'Grants',
-        to: '/Explore/Grants',
+        to: 'Grants',
         isNested: true,
         synapseConfigArray: [
           {
@@ -167,8 +165,7 @@ const routes: GenericRoute[] = [
         ],
         routes: [
           {
-            name: 'DetailsPage',
-            to: '/Explore/Grants/DetailsPage',
+            to: 'DetailsPage',
             isNested: false,
             synapseConfigArray: [
               {
@@ -243,8 +240,7 @@ const routes: GenericRoute[] = [
         ],
       },
       {
-        name: 'Publications',
-        to: '/Explore/Publications',
+        to: 'Publications',
         isNested: true,
         synapseConfigArray: [
           {
@@ -258,8 +254,7 @@ const routes: GenericRoute[] = [
         ],
         routes: [
           {
-            name: 'DetailsPage',
-            to: '/Explore/Publications/DetailsPage',
+            to: 'DetailsPage',
             isNested: false,
             synapseConfigArray: [
               {
@@ -312,8 +307,7 @@ const routes: GenericRoute[] = [
         ],
       },
       {
-        name: 'Datasets',
-        to: '/Explore/Datasets',
+        to: 'Datasets',
         isNested: true,
         synapseConfigArray: [
           {
@@ -327,8 +321,7 @@ const routes: GenericRoute[] = [
         ],
         routes: [
           {
-            name: 'DetailsPage',
-            to: '/Explore/Datasets/DetailsPage',
+            to: 'DetailsPage',
             isNested: false,
             synapseConfigArray: [
               {
@@ -375,8 +368,7 @@ const routes: GenericRoute[] = [
         ],
       },
       {
-        name: 'Files',
-        to: '/Explore/Files',
+        to: 'Files',
         isNested: false,
         synapseConfigArray: [
           {
@@ -390,8 +382,7 @@ const routes: GenericRoute[] = [
         ],
       },
       {
-        name: 'Tools',
-        to: '/Explore/Tools',
+        to: 'Tools',
         isNested: false,
         synapseConfigArray: [
           {
@@ -407,8 +398,7 @@ const routes: GenericRoute[] = [
     ],
   },
   {
-    name: 'About',
-    to: '/About',
+    to: 'About',
     isNested: false,
     synapseConfigArray: [
       {

--- a/src/configurations/crc-researcher/routesConfig.ts
+++ b/src/configurations/crc-researcher/routesConfig.ts
@@ -11,8 +11,7 @@ import routeButtonControlWrapperProps from './routeButtonControlWrapperProps'
 
 const routes: GenericRoute[] = [
   {
-    name: '',
-    to: '/',
+    to: '',
     isNested: false,
     synapseConfigArray: [
       {
@@ -52,13 +51,11 @@ const routes: GenericRoute[] = [
     ],
   },
   {
-    name: 'Explore',
     isNested: true,
-    to: '/',
+    to: 'Explore',
     routes: [
       {
-        name: '1. Uncategorized',
-        to: '/Explore/1. Uncategorized',
+        to: '1. Uncategorized',
         isNested: false,
         synapseConfigArray: [
           {
@@ -72,8 +69,7 @@ const routes: GenericRoute[] = [
         ],
       },
       {
-        name: '2. Potential',
-        to: '/Explore/2. Potential',
+        to: '2. Potential',
         isNested: false,
         synapseConfigArray: [
           {
@@ -87,8 +83,7 @@ const routes: GenericRoute[] = [
         ],
       },
       {
-        name: '3. Invited',
-        to: '/Explore/3. Invited',
+        to: '3. Invited',
         isNested: false,
         synapseConfigArray: [
           {
@@ -102,8 +97,7 @@ const routes: GenericRoute[] = [
         ],
       },
       {
-        name: '4. Scheduled',
-        to: '/Explore/4. Scheduled',
+        to: '4. Scheduled',
         isNested: false,
         synapseConfigArray: [
           {
@@ -117,8 +111,7 @@ const routes: GenericRoute[] = [
         ],
       },
       {
-        name: '5. Tested',
-        to: '/Explore/5. Tested',
+        to: '5. Tested',
         isNested: false,
         synapseConfigArray: [
           {
@@ -132,8 +125,7 @@ const routes: GenericRoute[] = [
         ],
       },
       {
-        name: 'Hidden',
-        to: '/Explore/Hidden',
+        to: 'Hidden',
         isNested: false,
         synapseConfigArray: [
           {

--- a/src/configurations/crc-researcher/routesConfig.ts
+++ b/src/configurations/crc-researcher/routesConfig.ts
@@ -52,10 +52,7 @@ const routes: GenericRoute[] = [
   },
   {
     isNested: true,
-<<<<<<< HEAD
     to: 'Explore',
-=======
->>>>>>> 91451f633e515aadfd8e4a692c3d051b47696351
     routes: [
       {
         to: '1. Uncategorized',

--- a/src/configurations/digitalhealth/routesConfig.ts
+++ b/src/configurations/digitalhealth/routesConfig.ts
@@ -7,8 +7,7 @@ import { toolsDetailsLandingPage } from './synapseConfigs/tools'
 
 const routes: GenericRoute[] = [
   {
-    name: '',
-    to: '/',
+    to: '',
     isNested: false,
     synapseConfigArray: [
       {
@@ -20,12 +19,11 @@ const routes: GenericRoute[] = [
     ],
   },
   {
-    name: 'Explore',
+    to: 'Explore',
     isNested: true,
     routes: [
       {
-        name: 'Studies',
-        to: '/Explore/Studies',
+        to: 'Studies',
         isNested: true,
         synapseConfigArray: [
           {
@@ -39,16 +37,14 @@ const routes: GenericRoute[] = [
         ],
         routes: [
           {
-            name: 'DetailsPage',
-            to: 'Explore/Studies/DetailsPage',
+            to: 'DetailsPage',
             isNested: false,
             synapseConfigArray: studyDetailPage,
           },
         ],
       },
       {
-        name: 'Projects',
-        to: '/Explore/Projects',
+        to: 'Projects',
         isNested: true,
         synapseConfigArray: [
           {
@@ -62,16 +58,14 @@ const routes: GenericRoute[] = [
         ],
         routes: [
           {
-            name: 'DetailsPage',
-            to: '/Explore/Projects/DetailsPage',
+            to: 'DetailsPage',
             isNested: false,
             synapseConfigArray: projectDetailPage,
           },
         ],
       },
       {
-        name: 'Data',
-        to: '/Explore/Data',
+        to: 'Data',
         isNested: false,
         synapseConfigArray: [
           {
@@ -85,8 +79,7 @@ const routes: GenericRoute[] = [
         ],
       },
       {
-        name: 'Tools',
-        to: '/Explore/Tools',
+        to: 'Tools',
         isNested: true,
         synapseConfigArray: [
           {
@@ -100,16 +93,14 @@ const routes: GenericRoute[] = [
         ],
         routes: [
           {
-            name: 'DetailsPage',
-            to: '/Explore/Tools/DetailsPage',
+            to: 'DetailsPage',
             isNested: false,
             synapseConfigArray: toolsDetailsLandingPage,
           },
         ],
       },
       {
-        name: 'Publications',
-        to: '/Explore/Publications',
+        to: 'Publications',
         isNested: false,
         synapseConfigArray: [
           {
@@ -125,8 +116,7 @@ const routes: GenericRoute[] = [
     ],
   },
   {
-    name: 'About',
-    to: '/About',
+    to: 'About',
     isNested: false,
     synapseConfigArray: [
       {

--- a/src/configurations/htan/routesConfig.ts
+++ b/src/configurations/htan/routesConfig.ts
@@ -23,8 +23,7 @@ import facetAliases from './facetAliases'
 
 const routes: GenericRoute[] = [
   {
-    name: '',
-    to: '/',
+    to: '',
     isNested: false,
     synapseConfigArray: [
       {
@@ -148,12 +147,11 @@ const routes: GenericRoute[] = [
     ],
   },
   {
-    name: 'Explore',
+    to: 'Explore',
     isNested: true,
     routes: [
       {
-        name: 'Grants',
-        to: '/Explore/Grants',
+        to: 'Grants',
         isNested: true,
         synapseConfigArray: [
           {
@@ -167,8 +165,7 @@ const routes: GenericRoute[] = [
         ],
         routes: [
           {
-            name: 'DetailsPage',
-            to: '/Explore/Grants/DetailsPage',
+            to: 'DetailsPage',
             isNested: false,
             synapseConfigArray: [
               {
@@ -244,8 +241,7 @@ const routes: GenericRoute[] = [
         ],
       },
       {
-        name: 'Publications',
-        to: '/Explore/Publications',
+        to: 'Publications',
         isNested: true,
         synapseConfigArray: [
           {
@@ -259,8 +255,7 @@ const routes: GenericRoute[] = [
         ],
         routes: [
           {
-            name: 'DetailsPage',
-            to: '/Explore/Publications/DetailsPage',
+            to: 'DetailsPage',
             isNested: false,
             synapseConfigArray: [
               {
@@ -313,8 +308,7 @@ const routes: GenericRoute[] = [
         ],
       },
       {
-        name: 'Datasets',
-        to: '/Explore/Datasets',
+        to: 'Datasets',
         isNested: true,
         synapseConfigArray: [
           {
@@ -328,8 +322,7 @@ const routes: GenericRoute[] = [
         ],
         routes: [
           {
-            name: 'DetailsPage',
-            to: '/Explore/Datasets/DetailsPage',
+            to: 'DetailsPage',
             isNested: false,
             synapseConfigArray: [
               {
@@ -376,8 +369,7 @@ const routes: GenericRoute[] = [
         ],
       },
       {
-        name: 'Files',
-        to: '/Explore/Files',
+        to: 'Files',
         isNested: false,
         synapseConfigArray: [
           {
@@ -391,8 +383,7 @@ const routes: GenericRoute[] = [
         ],
       },
       {
-        name: 'Tools',
-        to: '/Explore/Tools',
+        to: 'Tools',
         isNested: false,
         synapseConfigArray: [
           {
@@ -408,8 +399,7 @@ const routes: GenericRoute[] = [
     ],
   },
   {
-    name: 'About',
-    to: '/About',
+    to: 'About',
     isNested: false,
     synapseConfigArray: [
       {

--- a/src/configurations/nf/routesConfig.ts
+++ b/src/configurations/nf/routesConfig.ts
@@ -29,8 +29,7 @@ const limit = 3
 
 const routes: GenericRoute[] = [
   {
-    name: '',
-    to: '/',
+    to: '',
     isNested: false,
     synapseConfigArray: [
       {
@@ -120,13 +119,12 @@ const routes: GenericRoute[] = [
     ],
   },
   {
-    name: 'Explore',
+    to: 'Explore',
     isNested: true,
     routes: [
       {
-        name: 'Studies',
         isNested: true,
-        to: '/Explore/Studies',
+        to: 'Studies',
         synapseConfigArray: [
           {
             name: 'RouteButtonControlWrapper',
@@ -139,8 +137,7 @@ const routes: GenericRoute[] = [
         ],
         routes: [
           {
-            name: 'DetailsPage',
-            to: 'Explore/Studies/DetailsPage',
+            to: 'DetailsPage',
             isNested: false,
             synapseConfigArray: [
               {
@@ -167,9 +164,8 @@ const routes: GenericRoute[] = [
         ],
       },
       {
-        name: 'Datasets',
         isNested: false,
-        to: '/Explore/Datasets',
+        to: 'Datasets',
         synapseConfigArray: [
           {
             name: 'RouteButtonControlWrapper',
@@ -182,9 +178,8 @@ const routes: GenericRoute[] = [
         ],
       },
       {
-        name: 'Files',
         isNested: false,
-        to: '/Explore/Files',
+        to: 'Files',
         synapseConfigArray: [
           {
             name: 'RouteButtonControlWrapper',
@@ -197,9 +192,8 @@ const routes: GenericRoute[] = [
         ],
       },
       {
-        name: 'Publications',
         isNested: false,
-        to: '/Explore/Publications',
+        to: 'Publications',
         synapseConfigArray: [
           {
             name: 'RouteButtonControlWrapper',
@@ -212,9 +206,8 @@ const routes: GenericRoute[] = [
         ],
       },
       {
-        name: 'Tools',
         isNested: false,
-        to: '/Explore/Tools',
+        to: 'Tools',
         synapseConfigArray: [
           {
             name: 'RouteButtonControlWrapper',
@@ -229,56 +222,49 @@ const routes: GenericRoute[] = [
     ],
   },
   {
-    name: 'Organizations',
+    to: 'Organizations',
     isNested: true,
     routes: [
       {
         displayName: 'CTF',
-        name: 'DetailsPage',
-        to: '/Organizations/DetailsPage?abbreviation=CTF',
+        to: 'DetailsPage?abbreviation=CTF',
         isNested: false,
-        programmaticRouteConfig: organizationDetailsPage,
+        synapseConfigArray: organizationDetailsPage,
       },
       {
         displayName: 'NTAP',
-        name: 'DetailsPage',
-        to: '/Organizations/DetailsPage?abbreviation=NTAP',
+        to: 'DetailsPage?abbreviation=NTAP',
         isNested: false,
-        programmaticRouteConfig: organizationDetailsPage,
+        synapseConfigArray: organizationDetailsPage,
       },
       {
         displayName: 'GFF',
-        name: 'DetailsPage',
-        to: '/Organizations/DetailsPage?abbreviation=GFF',
+        to: 'DetailsPage?abbreviation=GFF',
         isNested: false,
-        programmaticRouteConfig: organizationDetailsPage,
+        synapseConfigArray: organizationDetailsPage,
       },
       {
         displayName: 'NCI DHART SPORE',
-        name: 'DetailsPage',
-        to: '/Organizations/DetailsPage?fundingAgency=NIH-NCI',
+        to: 'DetailsPage?fundingAgency=NIH-NCI',
         isNested: false,
-        programmaticRouteConfig: organizationDetailsPage,
+        synapseConfigArray: organizationDetailsPage,
       },
       {
         displayName: 'CDMRP NFRP',
-        name: 'DetailsPage',
-        to: '/Organizations/DetailsPage?abbreviation=CDMRP',
+        to: 'DetailsPage?abbreviation=CDMRP',
         isNested: false,
-        programmaticRouteConfig: organizationDetailsPage,
+        synapseConfigArray: organizationDetailsPage,
       },
       {
         displayName: 'NFRI',
-        name: 'DetailsPage',
-        to: '/Organizations/DetailsPage?abbreviation=NFRI',
+        to: 'DetailsPage?abbreviation=NFRI',
         isNested: false,
-        programmaticRouteConfig: organizationDetailsPage,
+        synapseConfigArray: organizationDetailsPage,
       },
     ],
   },
   {
-    name: 'About',
-    to: '/About',
+    to: 'About',
     isNested: false,
     synapseConfigArray: [
       {

--- a/src/configurations/psychencode/routesConfig.ts
+++ b/src/configurations/psychencode/routesConfig.ts
@@ -10,8 +10,7 @@ import { peopleSql } from './resources'
 
 const routes: GenericRoute[] = [
   {
-    name: '',
-    to: '/',
+    to: '',
     isNested: false,
     synapseConfigArray: [
       {
@@ -97,12 +96,11 @@ const routes: GenericRoute[] = [
     ],
   },
   {
-    name: 'Explore',
+    to: 'Explore',
     isNested: true,
     routes: [
       {
-        name: 'Studies',
-        to: '/Explore/Studies',
+        to: 'Studies',
         isNested: true,
         synapseConfigArray: [
           {
@@ -116,16 +114,14 @@ const routes: GenericRoute[] = [
         ],
         routes: [
           {
-            name: 'DetailsPage',
-            to: 'Explore/Studies/DetailsPage',
+            to: 'DetailsPage',
             isNested: false,
             synapseConfigArray: studyDetailPage,
           },
         ],
       },
       {
-        name: 'Data',
-        to: '/Explore/Data',
+        to: 'Data',
         isNested: false,
         synapseConfigArray: [
           {
@@ -139,8 +135,7 @@ const routes: GenericRoute[] = [
         ],
       },
       {
-        name: 'Grants',
-        to: '/Explore/Grants',
+        to: 'Grants',
         isNested: true,
         synapseConfigArray: [
           {
@@ -154,16 +149,14 @@ const routes: GenericRoute[] = [
         ],
         routes: [
           {
-            name: 'DetailsPage',
-            to: 'Explore/Grants/DetailsPage',
+            to: 'DetailsPage',
             isNested: false,
             synapseConfigArray: grantsDetailPage,
           },
         ],
       },
       {
-        name: 'Publications',
-        to: '/Explore/Publications',
+        to: 'Publications',
         isNested: false,
         synapseConfigArray: [
           {
@@ -177,8 +170,7 @@ const routes: GenericRoute[] = [
         ],
       },
       {
-        name: 'People',
-        to: '/Explore/People',
+        to: 'People',
         isNested: false,
         synapseConfigArray: [
           {
@@ -194,9 +186,8 @@ const routes: GenericRoute[] = [
     ],
   },
   {
-    name: 'DataAccess',
     displayName: 'Data Access',
-    to: '/DataAccess',
+    to: 'DataAccess',
     isNested: false,
     synapseConfigArray: [
       {
@@ -209,8 +200,7 @@ const routes: GenericRoute[] = [
     ],
   },
   {
-    name: 'About',
-    to: '/About',
+    to: 'About',
     isNested: false,
     synapseConfigArray: [
       {

--- a/src/configurations/stopadportal/routesConfig.ts
+++ b/src/configurations/stopadportal/routesConfig.ts
@@ -2,8 +2,7 @@ import { GenericRoute } from 'types/portal-config'
 
 const routes: GenericRoute[] = [
   {
-    name: '',
-    to: '/',
+    to: '',
     isNested: false,
     synapseConfigArray: [
       {
@@ -17,8 +16,7 @@ const routes: GenericRoute[] = [
     ],
   },
   {
-    name: 'Apply',
-    to: '/Apply',
+    to: 'Apply',
     isNested: false,
     synapseConfigArray: [
       {
@@ -53,13 +51,11 @@ const routes: GenericRoute[] = [
     ],
   },
   {
-    name: 'Help',
-    to: '/Help',
+    to: 'Help',
     isNested: true,
     routes: [
       {
-        name: 'How It Works',
-        to: '/Help/How It Works',
+        to: 'How It Works',
         isNested: false,
         synapseConfigArray: [
           {
@@ -73,8 +69,7 @@ const routes: GenericRoute[] = [
         ],
       },
       {
-        name: 'Data Requirements',
-        to: '/Help/Data Requirements',
+        to: 'Data Requirements',
         isNested: false,
         synapseConfigArray: [
           {
@@ -90,8 +85,7 @@ const routes: GenericRoute[] = [
     ],
   },
   {
-    name: 'Terms',
-    to: '/Terms',
+    to: 'Terms',
     isNested: false,
     hideRouteFromNavbar: true,
     synapseConfigArray: [
@@ -106,8 +100,7 @@ const routes: GenericRoute[] = [
   },
   // https://www.synapse.org/#!Synapse:syn20717442/wiki/596047
   {
-    name: 'Contact Us',
-    to: '/Contact Us',
+    to: 'Contact Us',
     isNested: false,
     hideRouteFromNavbar: true,
     synapseConfigArray: [

--- a/src/test-configuration/routesConfig.ts
+++ b/src/test-configuration/routesConfig.ts
@@ -8,12 +8,11 @@ export const EXPLORE_INDEX = 1
 export const ORGANIZATION_INDEX = 2
 export const HOME_INDEX = 0
 
-const routes: GenericRoute[] = []
+const routes: GenericRoute[] = new Array(4).fill(undefined)
 
 routes[ABOUT_INDEX] = {
   isNested: false,
-  name: 'About',
-  to: '/About',
+  to: 'About',
   synapseConfigArray: [
     {
       title: 'About',
@@ -27,32 +26,29 @@ routes[ABOUT_INDEX] = {
 }
 
 routes[EXPLORE_INDEX] = {
-  name: 'Explore',
+  to: 'Explore',
   isNested: true,
   routes: [
     {
-      name: 'Data',
       isNested: false,
-      to: '/Explore/Data',
+      to: 'Data',
       synapseConfigArray: [studies.explorePageSynapseObject],
     },
     {
-      name: 'Publications',
       isNested: false,
-      to: '/Explore/Publications',
+      to: 'Publications',
       synapseConfigArray: [publications.explorePageSynapseObject],
     },
   ],
 }
 
 routes[ORGANIZATION_INDEX] = {
-  name: 'Organizations',
+  to: 'Organizations',
   isNested: true,
   routes: [
     {
-      name: 'Content',
       isNested: true,
-      to: '/Organizations/Content',
+      to: 'Content',
       synapseConfigArray: [
         {
           title: 'Grants',
@@ -78,9 +74,8 @@ routes[ORGANIZATION_INDEX] = {
       ],
       routes: [
         {
-          name: 'Subcontent',
+          to: 'Subcontent',
           isNested: false,
-          to: '/Organizations/Content/Subcontent',
           synapseConfigArray: [
             {
               name: 'Markdown',
@@ -97,8 +92,7 @@ routes[ORGANIZATION_INDEX] = {
 }
 
 routes[HOME_INDEX] = {
-  name: '',
-  to: '/',
+  to: '',
   isNested: false,
   synapseConfigArray: [
     {

--- a/src/test-configuration/routesConfig.ts
+++ b/src/test-configuration/routesConfig.ts
@@ -8,7 +8,7 @@ export const EXPLORE_INDEX = 1
 export const ORGANIZATION_INDEX = 2
 export const HOME_INDEX = 0
 
-const routes: GenericRoute[] = new Array(4).fill(undefined)
+const routes: GenericRoute[] = []
 
 routes[ABOUT_INDEX] = {
   isNested: false,

--- a/src/types/portal-config.ts
+++ b/src/types/portal-config.ts
@@ -245,12 +245,11 @@ export type HomeExploreConfig = {
 }
 
 interface RouteOptions {
-  name: string
   displayName?: string
   isNested: boolean
   programmaticRouteConfig?: SynapseConfigArray
   hideRouteFromNavbar?: boolean
-  to?: string
+  to: string | undefined
   link?: string
   icon?: string
   synapseConfigArray?: SynapseConfigArray


### PR DESCRIPTION
This change removes the `name` prop in the route object and only uses the `to` prop
This simplifies things because it removes the dependency which had `name` equal to the last part of the `to` string in the route object
**Before**
```ts
{
   to: 'Explore',
   ...
   routes: [
       {
           name: 'Studies', // this value had to equal to Studies in 'to' below
           to: 'Explore/Studies'
       }
   ]
}
```

**Now**
nested routes build the route by concatenating the `to` prop, e.g.
```ts
{
   to: 'Explore',
   ...
   routes: [
       {
           to: 'Studies' // this points to Explore/Studies
       }
   ]
}
```

In total: this removes a prop, a fragile convention, and is more intuitive.

Other-
The `to` prop must always be defined, however, the `link` prop is an escape that lets a route point to a specific destination (there are a cases where links should point out of the portal from the navbar).
Also removed an unnecessary if statement from the navbar


