### PR TITLE
PORTALS-1755: Add study metadata on study details page

### DIFF
--- a/src/configurations/adknowledgeportal/synapseConfigs/studies.ts
+++ b/src/configurations/adknowledgeportal/synapseConfigs/studies.ts
@@ -172,8 +172,15 @@ export const studiesDetailsPageProps: DetailsPageProps = {
       tabIndex: 1,
     },
     {
-      name: 'StandaloneQueryWrapper',
+      name: 'Markdown',
       title: 'Study Metadata',
+      columnName: 'studyMetadata',
+      props: {},
+      tabIndex: 1,
+    },
+    {
+      name: 'StandaloneQueryWrapper',
+      showTitleSeperator: false,
       columnName: 'Study',
       resolveSynId: {
         value: true,


### PR DESCRIPTION
<img width="1670" alt="Screen Shot 2020-12-17 at 2 54 03 PM" src="https://user-images.githubusercontent.com/434792/102553486-c7110780-4077-11eb-9c02-6019c9b8b0a1.png">
