### PR TITLE
PORTALS-1797: CSS fixes for mobile top nav

### DIFF
--- a/src/Navbar.scss
+++ b/src/Navbar.scss
@@ -70,6 +70,7 @@
         text-align: left;
         margin: 0;
         text-transform: unset;
+        height: auto;
 
         &:hover {
           background-color: $primary-action-color;
@@ -119,10 +120,24 @@
       .dropdown-menu>li>a {
         padding: 3px $mb-menu-item-padding
       }
+
+      .Download-Link {
+        text-align: left;
+        padding: 20px 42px;
+
+        // Download size
+        .position-by-button {
+          position: relative;
+          display: inline-block;
+          top: -14px;
+          right: 16px;
+        }
+      }
+
     }
 
     .user-loggedIn {
-      display: none;
+      display: none !important; // to override another important
     }
 
     .user-loggedIn-mb {


### PR DESCRIPTION
1. Reset menu item height to `auto` instead of 100%
2. Make sure desktop menu to be hidden when in mobile view (need overwrite important from another place)
3. Fix download link and download size alignment in mobile view

<img width="447" alt="Screen Shot 2021-01-04 at 5 30 25 PM" src="https://user-images.githubusercontent.com/434792/103596580-172efd00-4eb3-11eb-9de6-024b6fa972bc.png">
