### PR TITLE
metadatasql points to datasynid

### DIFF
--- a/src/configurations/psychencode/resources.ts
+++ b/src/configurations/psychencode/resources.ts
@@ -4,7 +4,7 @@
 const dataSynId = 'syn20821313.5'
 export const studiesSql = 'SELECT * FROM syn21783965.4'
 export const dataSql = `SELECT * FROM ${dataSynId}`
-export const metadataSql = 'SELECT id, metadataType, dataType, assay FROM syn20821313 WHERE "dataSubtype" = \'metadata\''
+export const metadataSql = 'SELECT id, metadataType, dataType, assay FROM ${dataSynId} WHERE "dataSubtype" = \'metadata\''
 export const peopleSql = 'SELECT * FROM syn22096112.3'
 export const grantSql = 'SELECT * FROM syn22096130.4'
 export const publicationSql = 'SELECT * FROM syn22095937.4 order by authors asc'


### PR DESCRIPTION
Remove redundancy, and reuse `dataSynId`.