### PR TITLE
new about page wiki

### DIFF
--- a/src/configurations/psychencode/routesConfig.ts
+++ b/src/configurations/psychencode/routesConfig.ts
@@ -218,7 +218,7 @@ const routes: GenericRoute[] = [
         title: 'About',
         props: {
           ownerId: 'syn4921369',
-          wikiId: '235539',
+          wikiId: '607829',
         },
       },
     ],


### PR DESCRIPTION
My goal is to keep the content the same but point to a wiki sub-page, instead of the Project wiki main page.