### PR TITLE
PORTALS-1803: change AD metadata table to use explore 2.0, but hide visualizations by default.

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "react-spinners": "^0.8.3",
     "sass": "^1.30.0",
     "source-map-explorer": "^1.6.0",
-    "synapse-react-client": "1.15.62",
+    "synapse-react-client": "1.15.63",
     "typescript": "3.8.3"
   },
   "jest": {

--- a/src/configurations/adknowledgeportal/synapseConfigs/studies.ts
+++ b/src/configurations/adknowledgeportal/synapseConfigs/studies.ts
@@ -179,7 +179,7 @@ export const studiesDetailsPageProps: DetailsPageProps = {
       tabIndex: 1,
       props: {
         sqlOperator: 'HAS',
-        showColumnSelection: false,
+        showColumnSelection: true,
         rgbIndex,
         name: 'Metadata Files',
         visibleColumnCount: 10,
@@ -187,8 +187,10 @@ export const studiesDetailsPageProps: DetailsPageProps = {
           showAccessColumn: true,
           showDownloadColumn: true,
         },
+        facetsToFilter:['tissue'],
         sql: "SELECT id, metadataType, dataType, assay FROM syn11346063 WHERE `dataSubtype` = 'metadata'",
         shouldDeepLink: false,
+        defaultShowFacetVisualization: false,
       },
       resolveSynId: {
         value: true,

--- a/src/configurations/adknowledgeportal/synapseConfigs/studies.ts
+++ b/src/configurations/adknowledgeportal/synapseConfigs/studies.ts
@@ -175,25 +175,27 @@ export const studiesDetailsPageProps: DetailsPageProps = {
       tabIndex: 1,
     },
     {
-      name: 'StandaloneQueryWrapper',
-      showTitleSeperator: false,
-      columnName: 'Study',
+      name: "QueryWrapperPlotNav",
+      tabIndex: 1,
+      props: {
+        sqlOperator: 'HAS',
+        showColumnSelection: false,
+        rgbIndex,
+        name: 'Metadata Files',
+        visibleColumnCount: 10,
+        tableConfiguration: {
+          showAccessColumn: true,
+          showDownloadColumn: true,
+        },
+        sql: "SELECT id, metadataType, dataType, assay FROM syn11346063 WHERE `dataSubtype` = 'metadata'",
+        shouldDeepLink: false,
+      },
       resolveSynId: {
         value: true,
       },
       tableSqlKeys: ['study'],
-      props: {
-        sql:
-          "SELECT id, metadataType, dataType, assay FROM syn11346063 WHERE `dataSubtype` = 'metadata'",
-        facetAliases,
-        rgbIndex,
-        unitDescription: 'Files',
-        title: 'Metadata Files',
-        sqlOperator: 'HAS'
-      },
-      tabIndex: 1,
-      className: 'metadata-table'
-    },
+      columnName: 'Study'
+    },    
     {
       name: "QueryWrapperPlotNav",
       tabIndex: 1,

--- a/src/configurations/adknowledgeportal/synapseConfigs/studies.ts
+++ b/src/configurations/adknowledgeportal/synapseConfigs/studies.ts
@@ -187,7 +187,7 @@ export const studiesDetailsPageProps: DetailsPageProps = {
           showAccessColumn: true,
           showDownloadColumn: true,
         },
-        facetsToFilter:['tissue'],
+        facetsToFilter:['metadataType', 'dataType', 'assay'],
         sql: "SELECT id, metadataType, dataType, assay FROM syn11346063 WHERE `dataSubtype` = 'metadata'",
         shouldDeepLink: false,
         defaultShowFacetVisualization: false,

--- a/yarn.lock
+++ b/yarn.lock
@@ -11685,10 +11685,10 @@ symbol-tree@^3.2.2:
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.4.tgz"
   integrity sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==
 
-synapse-react-client@1.15.62:
-  version "1.15.62"
-  resolved "https://registry.yarnpkg.com/synapse-react-client/-/synapse-react-client-1.15.62.tgz#358187efe0e8d22c3869dc96efdcb6ee63b3792e"
-  integrity sha512-4GDxNAOHIKb770XrU+0krLwY9RUvZcwBfJQVWImHxupc8EfVFGW+3EEOakQjnbQLtv0NEChXWqiF/w5KA8PKzg==
+synapse-react-client@1.15.63:
+  version "1.15.63"
+  resolved "https://registry.yarnpkg.com/synapse-react-client/-/synapse-react-client-1.15.63.tgz#13f859998dbb867390101586354727f43bdaff73"
+  integrity sha512-i+Z7rz4JZOvsAiJcb2XSl9UoWvrtBkLb9+Fn2Gj3JBeugj9kPUzWkrDrFYV3RNluSwb/WiO/ijO6u/RNvvL3Bw==
   dependencies:
     "@brainhubeu/react-carousel" "1.19.26"
     "@fortawesome/fontawesome-free" "^5.13.0"


### PR DESCRIPTION
Also filter the facets (for left-hand facet value navigation).