### PR TITLE
work around opacity percentage bug during bundle creation

### DIFF
--- a/src/_Core.scss
+++ b/src/_Core.scss
@@ -591,7 +591,7 @@ div.SRC-marginBottomTen {
     width: 100%; height: 100%;
     background: white;
     z-index: -1;
-    opacity: 93%;
+    opacity: 0.93;
   }
   color: #323131;
   border-radius: 0px;


### PR DESCRIPTION
supposedly fixed, but I'm seeing it as 1% in the output bundle.
https://github.com/facebook/create-react-app/issues/7980