### PR TITLE
Change Docs link

### DIFF
--- a/src/configurations/nf/routesConfig.ts
+++ b/src/configurations/nf/routesConfig.ts
@@ -399,10 +399,10 @@ const routes: GenericRoute[] = [
   },
   {
     isNested: false,
-    displayName: 'Docs',
+    displayName: 'Help',
     to: undefined,
     target: '_blank',
-    link: 'https://nf-osi.github.io/',
+    link: 'https://help.nf.synapse.org/',
     synapseConfigArray: [],
   },
 ]


### PR DESCRIPTION
Changing the NF portal header link "Docs" to "Help" and changing the link from the github.io docs site to the new confluence docs site. I think I've changed this in the only place it needs to be changed, but I don't _really_ know what I'm doing, and I have no ability to test locally. :) 