### PR TITLE
Portals-1875: extra border radius

### DIFF
--- a/src/_Navbar.scss
+++ b/src/_Navbar.scss
@@ -80,6 +80,7 @@
         background-color: Portal.$secondary-action-color;
         color: #fff;
         border-bottom: 0;
+        border-radius: 0;
       }
 
       .nav-button-signin {


### PR DESCRIPTION
Remove extra border-radius style inherited from .btn css for mobile nav menu. 