### PR TITLE
add grant DOI to study card

### DIFF
--- a/src/configurations/nf/synapseConfigs/studies.ts
+++ b/src/configurations/nf/synapseConfigs/studies.ts
@@ -45,6 +45,7 @@ export const studyCardConfiguration: CardConfiguration = {
       'fundingAgency',
       'institutions',
       'studyId',
+      'grantDOI',
     ],
     dataTypeIconNames: 'dataType'
   },
@@ -119,6 +120,7 @@ const studies: HomeExploreConfig = {
           'diseaseFocus',
           'manifestation',
           'fundingAgency',
+          'grantDOI'
         ],
       },
     },

--- a/src/configurations/nf/synapseConfigs/studies.ts
+++ b/src/configurations/nf/synapseConfigs/studies.ts
@@ -120,7 +120,7 @@ const studies: HomeExploreConfig = {
           'diseaseFocus',
           'manifestation',
           'fundingAgency',
-          'grantDOI'
+          'grantDOI',
         ],
       },
     },


### PR DESCRIPTION
added ` 'grantDOI'` to study card metadata values and added it to the 'searchable' list. 