### PR TITLE
Style tweaks

### DIFF
--- a/src/RouteControl.tsx
+++ b/src/RouteControl.tsx
@@ -1,5 +1,5 @@
 import React, { useLayoutEffect, useRef } from 'react'
-import { Tab, Tabs } from '@material-ui/core'
+import { Tab, Tabs, TabScrollButton } from '@material-ui/core'
 import { useShowDesktop } from 'utils'
 export type NamedRoute = {
   name: string
@@ -51,6 +51,10 @@ export const RouteControl: React.FunctionComponent<RouteControlProps> = ({
     )
   }
 
+  const CustomScrollButton = (props) => {
+    return <TabScrollButton {...props} classes={{ root: 'TabScrollButton' }} />
+  }
+
   /**
    * In the desktop view, we use Material UI tabs
    */
@@ -59,6 +63,7 @@ export const RouteControl: React.FunctionComponent<RouteControlProps> = ({
       value={customRoutes.find((name) => isSelected(name))}
       variant="scrollable"
       scrollButtons="auto"
+      ScrollButtonComponent={CustomScrollButton}
       aria-label="Explore Sections"
       className="flex-display nav explore-nav"
     >

--- a/src/_Core.scss
+++ b/src/_Core.scss
@@ -203,6 +203,10 @@ body {
   &.explore-nav {
     margin-left: -24px;
     height: unset;
+    .MuiTabScrollButton-root .MuiSvgIcon-root {
+      color: Portal.$secondary-action-color;
+      font-size: 26px;
+    }
     .nav-button {
       height: 75px;
       .explore-nav-button-text {

--- a/src/_Core.scss
+++ b/src/_Core.scss
@@ -203,7 +203,7 @@ body {
   &.explore-nav {
     margin-left: -24px;
     height: unset;
-    .MuiTabScrollButton-root .MuiSvgIcon-root {
+    .TabScrollButton svg {
       color: Portal.$secondary-action-color;
       font-size: 26px;
     }


### PR DESCRIPTION
Make the tab scroll button icons slightly bigger and apply the portals accent color

<img width="1164" alt="image" src="https://user-images.githubusercontent.com/17580037/135280066-1d715612-47bf-4121-a6a7-1b5b59e9f66c.png">