### PR TITLE
Expose id column

### DIFF
--- a/src/configurations/psychencode/resources.ts
+++ b/src/configurations/psychencode/resources.ts
@@ -1,7 +1,7 @@
 // Portal owners can change the versions of the resources by modifying the
 // version of the entity used in the sql below
 
-const dataSynId = 'syn20821313.13'
+const dataSynId = 'syn20821313.14'
 export const studiesSql = 'SELECT * FROM syn21783965.9'
 export const dataSql = `SELECT * FROM ${dataSynId}`
 export const metadataSql = `SELECT id, metadataType, dataType, assay FROM ${dataSynId} WHERE "resourceType" = \'metadata\'`

--- a/src/configurations/psychencode/resources.ts
+++ b/src/configurations/psychencode/resources.ts
@@ -4,7 +4,7 @@
 const dataSynId = 'syn20821313.13'
 export const studiesSql = 'SELECT * FROM syn21783965.9'
 export const dataSql = `SELECT * FROM ${dataSynId}`
-export const metadataSql = `SELECT id, metadataType, dataType, assay FROM ${dataSynId} WHERE "dataSubtype" = \'metadata\'`
+export const metadataSql = `SELECT id, metadataType, dataType, assay FROM ${dataSynId} WHERE "resourceType" = \'metadata\'`
 export const peopleSql = 'SELECT * FROM syn22096112.3'
 export const grantSql = 'SELECT * FROM syn22096130.4'
 export const publicationSql = 'SELECT * FROM syn22095937.5 order by authors asc'

--- a/src/configurations/psychencode/synapseConfigs/data.ts
+++ b/src/configurations/psychencode/synapseConfigs/data.ts
@@ -3,7 +3,8 @@ import { SynapseConfig } from 'types/portal-config'
 import { dataSql } from '../resources'
 
 const facetAliases = {
-  id: 'File',
+  id: 'Id',
+  name: 'File Name'
 }
 
 const rgbIndex = 8
@@ -27,6 +28,7 @@ export const data: SynapseConfig = {
     },
     searchConfiguration: {
       searchable: [
+        'id',
         'study',
         'dataType',
         'resourceType',

--- a/src/configurations/psychencode/synapseConfigs/studies.ts
+++ b/src/configurations/psychencode/synapseConfigs/studies.ts
@@ -139,7 +139,8 @@ export const details: DetailsPageProps = {
       props: {
         sql: metadataSql,
         facetAliases: {
-          id: 'File Name',
+          id: 'Id',
+          name: 'File Name',
           metadataType: 'Metadata Type',
           dataType: 'Data Type',
           assay: 'Assay',


### PR DESCRIPTION
Given the change to the id column arriving with stack 379: [SWC-5806](https://sagebionetworks.jira.com/browse/SWC-5806), this PR: 
- fixes the facet alias, id is now actually the id and the name column can be faceted as "File Name"
- updated the metadataSql to AD standards by using the resourceType key
- increments the data view to test these changes