### PR TITLE
portal release 1.82

### DIFF
--- a/src/configurations/psychencode/resources.ts
+++ b/src/configurations/psychencode/resources.ts
@@ -1,11 +1,11 @@
 // Portal owners can change the versions of the resources by modifying the
 // version of the entity used in the sql below
 
-const dataSynId = 'syn20821313.13'
-export const studiesSql = 'SELECT * FROM syn21783965.9'
+const dataSynId = 'syn20821313.15'
+export const studiesSql = 'SELECT * FROM syn21783965.11'
 export const dataSql = `SELECT * FROM ${dataSynId}`
-export const metadataSql = `SELECT id, metadataType, dataType, assay FROM ${dataSynId} WHERE "dataSubtype" = \'metadata\'`
-export const peopleSql = 'SELECT * FROM syn22096112.3'
-export const grantSql = 'SELECT * FROM syn22096130.4'
-export const publicationSql = 'SELECT * FROM syn22095937.5 order by authors asc'
+export const metadataSql = `SELECT id, metadataType, dataType, assay FROM ${dataSynId} WHERE "resourceType" = \'metadata\'`
+export const peopleSql = 'SELECT * FROM syn22096112.4'
+export const grantSql = 'SELECT * FROM syn22096130.5'
+export const publicationSql = 'SELECT * FROM syn22095937.7 order by authors asc'
 export const upsetplotSql = `SELECT unnest(individualID), assay FROM ${dataSynId} WHERE individualID is not null GROUP BY assay, unnest(individualID)`


### PR DESCRIPTION
This PR: 
- increments the version for all views (people, grants, publications, studies and data).
- replaces the metadata query to use resourceType to match the way the AD portal is managed.