### PR TITLE
Add biobank secondaryLabels

### DIFF
--- a/src/configurations/nf/synapseConfigs/tools.ts
+++ b/src/configurations/nf/synapseConfigs/tools.ts
@@ -29,7 +29,7 @@ export const toolsSchema: GenericCardSchema = {
     'reactiveSpecies',
     'hostOrganism',
     'specimenTissueType',
-    'specimenPreparationMethod,
+    'specimenPreparationMethod',
     'diseaseType',
     'tumorType',
     'specimenFormat',

--- a/src/configurations/nf/synapseConfigs/tools.ts
+++ b/src/configurations/nf/synapseConfigs/tools.ts
@@ -27,7 +27,13 @@ export const toolsSchema: GenericCardSchema = {
     'animalModelOfManifestation',
     'targetAntigen',
     'reactiveSpecies',
-    'hostOrganism'
+    'hostOrganism',
+    'specimenTissueType',
+    'specimenPreparationMethod,
+    'diseaseType',
+    'tumorType',
+    'specimenFormat',
+    'specimenType'
   ],
 }
 


### PR DESCRIPTION
I made this change to the config in order to add these new secondaryLabels to the biobank cards on the portal (https://staging.nf.synapse.org/Explore/Tools/DetailsPage?resourceId=e4e60a43-9073-4dfa-a629-76b472451b7f). 

