### PR TITLE
fix user dropdown menu position

### DIFF
--- a/src/_Core.scss
+++ b/src/_Core.scss
@@ -317,10 +317,6 @@ button.dropdown-toggle.nav-button:hover {
   color: #515359;
 }
 
-.nav-user-menu {
-  left: 40px !important;
-}
-
 .portal-nav-menu {
   padding-top: 0px;
   padding-bottom: 0px;


### PR DESCRIPTION
Before
<img width="343" alt="Screen Shot 2022-06-07 at 11 52 54 AM" src="https://user-images.githubusercontent.com/1864447/172460134-d13b9c8d-3f49-45de-95a4-9552c1b62517.png">

After
<img width="315" alt="Screen Shot 2022-06-07 at 11 53 17 AM" src="https://user-images.githubusercontent.com/1864447/172460176-276e4fa4-c9bd-4f18-88dc-9e183590d815.png">


