### PR TITLE
AD portal 19.5 release patch

### DIFF
--- a/src/configurations/adknowledgeportal/resources.ts
+++ b/src/configurations/adknowledgeportal/resources.ts
@@ -1,7 +1,7 @@
 export const computationalSql = 'Select * from syn20337467'
-export const dataSql = 'SELECT * FROM syn11346063.26'
+export const dataSql = 'SELECT * FROM syn11346063.27'
 export const dataOnStudiesPageSql =
-  "SELECT id, name, metadataType, dataType, assay FROM syn11346063.26 WHERE `resourceType` = 'metadata'"
+  "SELECT id, name, metadataType, dataType, assay FROM syn11346063.27 WHERE `resourceType` = 'metadata'"
 export const peopleSql = 'SELECT * FROM syn13897207'
 export const projectsSql = 'SELECT * FROM syn17024229 ORDER BY isFeatured DESC'
 export const publicationsSql = 'SELECT * FROM syn20448807'


### PR DESCRIPTION
A few last minute updates for our 19.5 data release:
- add the "name" column to the SQL for the metadata file table on study pages, since the id column now displays as synID rather than a link including the filename
- re-version the file view to accommodate a last minute update to a few files