### PR TITLE
Update columnName and tableSqlKeys in CCKP's Grant Details page

### DIFF
--- a/src/configurations/cancercomplexity/routesConfig.ts
+++ b/src/configurations/cancercomplexity/routesConfig.ts
@@ -188,9 +188,9 @@ const routes: GenericRoute[] = [
                   synapseConfigArray: [
                     {
                       name: 'CardContainerLogic',
-                      columnName: 'grantName',
+                      columnName: 'grantNumber',
                       title: 'Related Projects',
-                      tableSqlKeys: ['grantName'],
+                      tableSqlKeys: ['grant'],
                       props: {
                         sqlOperator: 'LIKE',
                         sql: `${projectsSql} where grantType LIKE '%U54%'`,


### PR DESCRIPTION
I noticed as I was poking around the portal that using values with commas in them as the key between tables result in unexpected behavior, e.g. [this grant](https://cancercomplexity.synapse.org/Explore/Grants/DetailsPage?grantId=syn17084053) and its related projects:

![before](https://user-images.githubusercontent.com/9377970/173736401-c9cd2b22-6f2d-4289-91d0-d720827c0e68.png)

I'm guessing the two commas in the grant name is causing the query to mistake there being three "values" to search for instead of one.  After updating the config to use grant number instead of grant name, the text blurb now only shows up once:

![after](https://user-images.githubusercontent.com/9377970/173736688-5629687e-b219-49d8-af4c-ac45e30b0569.png)
