### PR TITLE
implement feedback from team regarding people cards

### DIFF
--- a/src/configurations/cancercomplexity/synapseConfigs/people.ts
+++ b/src/configurations/cancercomplexity/synapseConfigs/people.ts
@@ -18,8 +18,8 @@ export const peopleSchema: GenericCardSchema = {
     'orcidId',
     'grantName',
     'consortium',
-    'synapseProfileLink',
     'workingGroupParticipation',
+    'synapseProfileLink',
   ],
 }
 

--- a/src/configurations/cancercomplexity/synapseConfigs/people.ts
+++ b/src/configurations/cancercomplexity/synapseConfigs/people.ts
@@ -19,7 +19,7 @@ export const peopleSchema: GenericCardSchema = {
     'grantName',
     'consortium',
     'synapseProfileLink',
-    'chairRoles',
+    'workingGroupParticipation',
   ],
 }
 

--- a/src/configurations/cancercomplexity/synapseConfigs/people.ts
+++ b/src/configurations/cancercomplexity/synapseConfigs/people.ts
@@ -15,10 +15,10 @@ export const peopleSchema: GenericCardSchema = {
   subTitle: 'lastKnownInstitution',
   description: '',
   secondaryLabels: [
-    'synapseProfileLink',
     'orcidId',
     'grantName',
     'consortium',
+    'synapseProfileLink',
     'chairRoles',
   ],
 }
@@ -30,7 +30,7 @@ const iconOptions: IconOptions = {
 
 export const peopleCardConfiguration: CardConfiguration = {
   type: SynapseConstants.GENERIC_CARD,
-  secondaryLabelLimit: 4,
+  secondaryLabelLimit: 3,
   iconOptions,
   genericCardSchema: peopleSchema,
   titleLinkConfig: {


### PR DESCRIPTION
From @aclayton555 :
> * I personally feel that we should remove the "Synapse Profile Link" from the People cards in the explore module because (IMO) it tricks you into clicking on that profile, instead of navigating to the People details page/profile. Within the People Details page, I would also order the Synapse profile link after ORCID, Grant name and Consortium.
> * Now I am thinking that we shouldn't show Chair roles at all (because this will be "none" for a lot of people), and instead show the Working Group Participation data if that is possible? I think would be more meaningful 