### PR TITLE
add mapping from People -> Grant

### DIFF
--- a/src/configurations/cancercomplexity/routesConfig.ts
+++ b/src/configurations/cancercomplexity/routesConfig.ts
@@ -205,7 +205,7 @@ const routes: GenericRoute[] = [
                       title: 'Related People',
                       tableSqlKeys: ['grantNumber'],
                       props: {
-                        sqlOperator: 'LIKE',
+                        sqlOperator: 'HAS',
                         sql: peopleSql,
                         ...peopleCardConfiguration,
                         facetAliases,

--- a/src/configurations/cancercomplexity/routesConfig.ts
+++ b/src/configurations/cancercomplexity/routesConfig.ts
@@ -280,6 +280,18 @@ const routes: GenericRoute[] = [
                   synapseConfigArray: [
                     {
                       name: 'CardContainerLogic',
+                      columnName: 'grantNumber',
+                      title: 'Related Grants',
+                      tableSqlKeys: ['grantNumber'],
+                      props: {
+                        sqlOperator: '=',
+                        sql: grantsSql,
+                        ...grantsCardConfiguration,
+                        facetAliases,
+                      },
+                    },
+                    {
+                      name: 'CardContainerLogic',
                       columnName: 'publicationId',
                       title: 'Related Publications',
                       tableSqlKeys: ['pubMedId'],

--- a/src/configurations/cancercomplexity/routesConfig.ts
+++ b/src/configurations/cancercomplexity/routesConfig.ts
@@ -201,6 +201,18 @@ const routes: GenericRoute[] = [
                     },
                     {
                       name: 'CardContainerLogic',
+                      columnName: 'grantNumber',
+                      title: 'Related People',
+                      tableSqlKeys: ['grantNumber'],
+                      props: {
+                        sqlOperator: 'LIKE',
+                        sql: peopleSql,
+                        ...peopleCardConfiguration,
+                        facetAliases,
+                      },
+                    },
+                    {
+                      name: 'CardContainerLogic',
                       columnName: 'grantName',
                       title: 'Related Publications',
                       tableSqlKeys: ['grantName'],


### PR DESCRIPTION
Requested by @aclayton555 :

> also wondering is if the Grant Name on the People Details pages can also link to the respective Grant Details page - similar to how Publications, etc Details pages do?

QC'd on my end and everything looks okay so far!

**Screenshots**
![person_with_grant](https://user-images.githubusercontent.com/9377970/176847503-de08e07d-8a8e-4a04-b23d-2aa6049408a8.png)

![person_with_mult_grants](https://user-images.githubusercontent.com/9377970/176847514-4c881ff5-e01e-419d-bbea-ad1cfaf6e7bd.png)

