### PR TITLE
PORTALS-2228 - "Copy link" and fix redirect

### DIFF
--- a/src/portal-components/DetailsPage/DetailsPage.tsx
+++ b/src/portal-components/DetailsPage/DetailsPage.tsx
@@ -395,7 +395,7 @@ export const DetailsPageSynapseConfigArray: React.FC<{
   const synapseConfigContent = (
     <>
       {synapseConfigArray.map((el: RowSynapseConfig, index) => {
-        const id = getComponentId(el, '', index)
+        const id = getComponentId(el)
         const { resolveSynId, showTitleSeperator = true } = el
         const key = JSON.stringify(el)
         const hasTitleFromSynId = resolveSynId && resolveSynId.title

--- a/src/portal-components/DetailsPage/DetailsPage.tsx
+++ b/src/portal-components/DetailsPage/DetailsPage.tsx
@@ -21,6 +21,7 @@ import {
   QueryBundleRequest,
   QueryResultBundle,
 } from 'synapse-react-client/dist/utils/synapseTypes/'
+import Tooltip from 'synapse-react-client/dist/utils/tooltip/Tooltip'
 import { SynapseComponent } from 'SynapseComponent'
 import { SynapseConfig } from 'types/portal-config'
 import {
@@ -28,10 +29,10 @@ import {
   ResolveSynId,
   RowSynapseConfig,
 } from 'types/portal-util-types'
-import DetailsPageTabs from './DetailsPageTabs'
 import injectPropsIntoConfig from '../injectPropsIntoConfig'
-import { handleMenuClick, SideNavMenu } from './SideNavMenu'
 import ToggleSynapseObjects from '../ToggleSynapseObjects'
+import DetailsPageTabs from './DetailsPageTabs'
+import { SideNavMenu } from './SideNavMenu'
 import { getComponentId, useScrollOnMount } from './utils'
 
 const goToExplorePage = () => {
@@ -47,13 +48,10 @@ const goToExplorePage = () => {
 function HeadlineWithLink(props: { title: string; id: string }) {
   const { title, id } = props
   const [showLink, setShowLink] = useState(false)
+  const [copied, setCopied] = useState(false)
 
   return (
     <div
-      style={{ cursor: 'pointer' }}
-      onClick={() => {
-        handleMenuClick(id)
-      }}
       onMouseOver={() => {
         setShowLink(true)
       }}
@@ -70,7 +68,26 @@ function HeadlineWithLink(props: { title: string; id: string }) {
             ...(showLink ? { display: 'inline' } : { display: 'none' }),
           }}
         >
-          <IconSvg options={{ icon: 'link', padding: 'left' }} />
+          <Tooltip
+            title={copied ? 'Copied' : 'Copy link to section'}
+            placement="right"
+          >
+            <div
+              style={{ cursor: 'pointer' }}
+              onClick={() => {
+                const urlWithoutHash = window.location.href.replace(
+                  window.location.hash,
+                  '',
+                )
+                const url = `${urlWithoutHash}#${id}`
+                navigator.clipboard.writeText(url).then(() => {
+                  setCopied(true)
+                })
+              }}
+            >
+              <IconSvg options={{ icon: 'link', padding: 'left' }} />
+            </div>
+          </Tooltip>
         </span>
       </Typography>
     </div>

--- a/src/portal-components/DetailsPage/DetailsPageTabs.tsx
+++ b/src/portal-components/DetailsPage/DetailsPageTabs.tsx
@@ -1,12 +1,18 @@
 import * as React from 'react'
 import { useState } from 'react'
-import { Icon } from 'synapse-react-client/dist/containers/row_renderers/utils'
+import {
+  NavLink,
+  Route,
+  Switch,
+  useLocation,
+  useRouteMatch,
+} from 'react-router-dom'
 import { BarLoader } from 'react-spinners'
-import { DetailsPageSynapseConfigArray } from './DetailsPage'
+import { Icon } from 'synapse-react-client/dist/containers/row_renderers/utils'
 import { QueryResultBundle } from 'synapse-react-client/dist/utils/synapseTypes'
-import { NavLink, Route, useLocation, useRouteMatch } from 'react-router-dom'
-import RedirectWithQuery from '../RedirectWithQuery'
 import { DetailsPageTabProps } from 'types/portal-util-types'
+import RedirectWithQuery from '../RedirectWithQuery'
+import { DetailsPageSynapseConfigArray } from './DetailsPage'
 
 export type DetailsPageTabsProps = {
   tabConfigs: DetailsPageTabProps[]
@@ -25,11 +31,14 @@ const DetailsPageTabs: React.FunctionComponent<DetailsPageTabsProps> = (
   const { search } = useLocation()
   return (
     <>
-      <RedirectWithQuery
-        exact={true}
-        from={urlWithTrailingSlash}
-        to={`${urlWithTrailingSlash}${tabConfigs[0].uriValue}`}
-      />
+      <Switch>
+        {/* Note -- `exact` in Redirect doesn't work without a Switch */}
+        <RedirectWithQuery
+          exact={true}
+          from={urlWithTrailingSlash}
+          to={`${urlWithTrailingSlash}${tabConfigs[0].uriValue}`}
+        />
+      </Switch>
       <div className="tab-groups">
         {tabConfigs.map((tab, index) => {
           return (

--- a/src/portal-components/DetailsPage/SideNavMenu.tsx
+++ b/src/portal-components/DetailsPage/SideNavMenu.tsx
@@ -63,7 +63,7 @@ export const SideNavMenu: React.FC<{
               onClick={
                 isDisabled
                   ? undefined
-                  : () => handleMenuClick(getComponentId(el, '', index))
+                  : () => handleMenuClick(getComponentId(el))
               }
               className={className}
             >

--- a/src/portal-components/DetailsPage/SideNavMenu.tsx
+++ b/src/portal-components/DetailsPage/SideNavMenu.tsx
@@ -63,7 +63,7 @@ export const SideNavMenu: React.FC<{
               onClick={
                 isDisabled
                   ? undefined
-                  : () => handleMenuClick(getComponentId(el))
+                  : () => handleMenuClick(getComponentId(el, '', index))
               }
               className={className}
             >

--- a/src/portal-components/DetailsPage/utils.ts
+++ b/src/portal-components/DetailsPage/utils.ts
@@ -6,10 +6,19 @@ import { scrollToWithOffset } from 'utils'
 export function getComponentId(
   rowSynapseConfig: RowSynapseConfig,
   entityTitle: string = '',
-  index: number = 0,
 ) {
+  // The ID should consist of the title and entity title
+  const idParts = [rowSynapseConfig.title, entityTitle].filter((item) => !!item)
+
+  // If both of the above are empty or undefined, use the component name
+  if (idParts.length === 0 && rowSynapseConfig.name) {
+    idParts.push(rowSynapseConfig.name)
+  }
+
+  // Join the parts with a '-'. If there are no parts, return an empty string.
   return (
-    `${rowSynapseConfig.title}-${entityTitle}-${rowSynapseConfig.name}-${index}`
+    idParts
+      .join('-')
       // Remove illegal characters for HTML5 IDs
       .replaceAll(/([^\d\w-])/g, '')
   )


### PR DESCRIPTION
- Clicking the link copies the URL to the section instead of navigating to it
- Fix an issue where the DetailsPageTab redirect would break navigating between tabs.
- Fix ID mismatch between SideNavMenu and rendered sections


Clip of "Copy link" functionality:

https://user-images.githubusercontent.com/17580037/180071249-4cbf5bdd-241e-4845-b51c-041283b6fe6c.mov

