### PR TITLE
PORTALS-2289: also remove container-fluid in Explore (since query wrapper plot nav …

### DIFF
--- a/src/_Core.scss
+++ b/src/_Core.scss
@@ -172,7 +172,7 @@ body {
 .explore-nav-container {
   background-color: #f9f9f9;
   border-bottom: 4px solid #dcdcdc;
-  padding: 30px 30px 0px 30px;
+  padding: 30px 30px 0px 45px;
   .title {
     margin-top: 0px;
   }

--- a/src/portal-components/RouteControlWrapper.tsx
+++ b/src/portal-components/RouteControlWrapper.tsx
@@ -50,31 +50,29 @@ const RouteControlWrapper: React.FunctionComponent<Props> = ({
   return (
     <>
       <div className="explore-nav-container">
-        <div className="container-fluid">
-          <h2 className="title">Explore</h2>
-          <h4 className={'mobile-explore-nav-selected'}>
-            {selectedTab}
-            {showSubNav ? (
-              <ArrowDropDown
-                fontSize={'large'}
-                onClick={() => setShowSubNav(false)}
-              />
-            ) : (
-              <ArrowDropUp
-                fontSize={'large'}
-                onClick={() => setShowSubNav(true)}
-              />
-            )}
-          </h4>
-          <div className={'route-control'}>
+        <h2 className="title">Explore</h2>
+        <h4 className={'mobile-explore-nav-selected'}>
+          {selectedTab}
+          {showSubNav ? (
+            <ArrowDropDown
+              fontSize={'large'}
+              onClick={() => setShowSubNav(false)}
+            />
+          ) : (
+            <ArrowDropUp
+              fontSize={'large'}
+              onClick={() => setShowSubNav(true)}
+            />
+          )}
+        </h4>
+        <div className={'route-control'}>
+          <RouteControl {...routeControlProps} />
+        </div>
+        {showSubNav && ( // default visibility for mobile sub menu is hidden
+          <div className={'mobile-route-control'}>
             <RouteControl {...routeControlProps} />
           </div>
-          {showSubNav && ( // default visibility for mobile sub menu is hidden
-            <div className={'mobile-route-control'}>
-              <RouteControl {...routeControlProps} />
-            </div>
-          )}
-        </div>
+        )}
       </div>
       <div>
         {synapseConfig && (


### PR DESCRIPTION
…now takes up the entire width)

Before:
<img width="1267" alt="Screen Shot 2022-08-24 at 10 03 11 AM" src="https://user-images.githubusercontent.com/1864447/186479945-a890e7f6-1746-46a4-8409-5b068554ad1c.png">

After:
<img width="1266" alt="Screen Shot 2022-08-24 at 10 05 13 AM" src="https://user-images.githubusercontent.com/1864447/186479966-898ab109-dd50-41e5-bd75-1a6ff17f0993.png">

