### PR TITLE
Total query results padding

### DIFF
--- a/src/_Core.scss
+++ b/src/_Core.scss
@@ -719,7 +719,11 @@ div[data-id="tooltip"] {
   .QueryFilter {
     padding: 10px 30px;
   }
+  .TotalQueryResults {
+    padding: 0px 30px;
+  }
 }
+
 .DetailsPage {
   .QueryWrapperPlotNav {
     .TopLevelControls,

--- a/src/_Core.scss
+++ b/src/_Core.scss
@@ -727,7 +727,8 @@ div[data-id="tooltip"] {
 .DetailsPage {
   .QueryWrapperPlotNav {
     .TopLevelControls,
-    .QueryFilter {
+    .QueryFilter,
+    .TotalQueryResults {
       padding: 0px;
     }
   } 


### PR DESCRIPTION
Pointing out the current issue:
<img width="1375" alt="Screen Shot 2022-08-31 at 3 07 10 PM" src="https://user-images.githubusercontent.com/1864447/187794129-127b2634-5384-4773-b2d4-8906b03483b7.png">
