### PR TITLE
CPO-328: Remove FILES from CCKP + card related updates

### DIFF
--- a/src/configurations/cancercomplexity/routeControlWrapperProps.ts
+++ b/src/configurations/cancercomplexity/routeControlWrapperProps.ts
@@ -3,7 +3,7 @@ import { RouteControlWrapperProps } from 'portal-components/RouteControlWrapper'
 const routeControlProps: RouteControlWrapperProps = {
   // this has to get overriden,
   synapseConfig: {} as SynapseConfig,
-  customRoutes: ['Grants', 'People', 'Publications', 'Datasets', 'Files', 'Tools'],
+  customRoutes: ['Grants', 'People', 'Publications', 'Datasets', 'Tools'],
 }
 
 export default routeControlProps

--- a/src/configurations/cancercomplexity/routesConfig.ts
+++ b/src/configurations/cancercomplexity/routesConfig.ts
@@ -404,6 +404,18 @@ const routes: GenericRoute[] = [
                   synapseConfigArray: [
                     {
                       name: 'CardContainerLogic',
+                      columnName: 'grantNumber',
+                      title: 'Related Grants',
+                      tableSqlKeys: ['grantNumber'],
+                      props: {
+                        sqlOperator: '=',
+                        sql: grantsSql,
+                        ...grantsCardConfiguration,
+                        facetAliases,
+                      },
+                    },
+                    {
+                      name: 'CardContainerLogic',
                       columnName: 'pubMedId',
                       title: 'Related People',
                       tableSqlKeys: ['publicationId'],

--- a/src/configurations/cancercomplexity/routesConfig.ts
+++ b/src/configurations/cancercomplexity/routesConfig.ts
@@ -1,7 +1,6 @@
 import { GenericRoute } from 'types/portal-config'
 import {
   publications,
-  files,
   datasets,
   grants,
   tools,
@@ -506,20 +505,6 @@ const routes: GenericRoute[] = [
                 },
               },
             ],
-          },
-        ],
-      },
-      {
-        path: 'Files',
-        exact: true,
-        synapseConfigArray: [
-          {
-            name: 'RouteControlWrapper',
-            isOutsideContainer: true,
-            props: {
-              ...RouteControlWrapperProps,
-              synapseConfig: files,
-            },
           },
         ],
       },

--- a/src/configurations/cancercomplexity/routesConfig.ts
+++ b/src/configurations/cancercomplexity/routesConfig.ts
@@ -18,7 +18,6 @@ import { onPointClick } from './synapseConfigs/onPointClick'
 import facetAliases from './facetAliases'
 import {
   datasetsSql,
-  filesSql,
   grantsSql,
   publicationSql,
   projectsSql,
@@ -486,19 +485,42 @@ const routes: GenericRoute[] = [
                 name: 'DetailsPage',
                 props: {
                   sql: datasetsSql,
-                  sqlOperator: 'LIKE',
-                  showMenu: false,
+                  sqlOperator: '=',
                   synapseConfigArray: [
                     {
-                      name: 'StandaloneQueryWrapper',
-                      title: 'Data',
-                      columnName: 'datasetAlias',
-                      tableSqlKeys: ['datasets'],
+                      name: 'CardContainerLogic',
+                      columnName: 'grantNumber',
+                      title: 'Related Grants',
+                      tableSqlKeys: ['grantNumber'],
                       props: {
-                        sql: filesSql,
                         sqlOperator: '=',
-                        rgbIndex: 0,
-                        title: 'Dataset Files',
+                        sql: grantsSql,
+                        ...grantsCardConfiguration,
+                        facetAliases,
+                      },
+                    },
+                    {
+                      name: 'CardContainerLogic',
+                      columnName: 'pubMedId',
+                      title: 'Related People',
+                      tableSqlKeys: ['publicationId'],
+                      props: {
+                        sqlOperator: 'LIKE',
+                        sql: peopleSql,
+                        ...peopleCardConfiguration,
+                        facetAliases,
+                      },
+                    },
+                    {
+                      name: 'CardContainerLogic',
+                      columnName: 'pubMedId',
+                      title: 'Related Publications',
+                      tableSqlKeys: ['pubMedId'],
+                      props: {
+                        sqlOperator: '=',
+                        sql: publicationSql,
+                        ...publicationsCardConfiguration,
+                        facetAliases,
                       },
                     },
                   ],

--- a/src/configurations/cancercomplexity/synapseConfigs/datasets.ts
+++ b/src/configurations/cancercomplexity/synapseConfigs/datasets.ts
@@ -12,13 +12,13 @@ export const datasetSchema: GenericCardSchema = {
   title: 'datasetName',
   description: 'description',
   secondaryLabels: [
-    'publicationTitle',
     'overallDesign',
     'tumorType',
+    'tissue',
     'assay',
     'species',
+    'fileFormats',
     'externalLink',
-    'grantName',
     'consortium',
   ],
 }

--- a/src/configurations/cancercomplexity/synapseConfigs/publications.ts
+++ b/src/configurations/cancercomplexity/synapseConfigs/publications.ts
@@ -21,9 +21,7 @@ export const publicationSchema: GenericCardSchema = {
     'assay',
     'keywords',
     'doi',
-    'grantName',
     'consortium',
-    'dataset',
   ],
 }
 


### PR DESCRIPTION
This PR addresses this [Jira ticket](https://sagebionetworks.jira.com/browse/CPO-328), specifically:

* Removing "Files" from the navigation bar and dropdown menu
* Replacing the table of data files in a Datasets Details Page with "Related *" cards
* Adding/removing secondary items to the Publications and Datasets cards (to make the cards as consistent as possible)