### PR TITLE
Remove secondary label to avoid redundancy

### DIFF
--- a/src/configurations/cancercomplexity/synapseConfigs/people.ts
+++ b/src/configurations/cancercomplexity/synapseConfigs/people.ts
@@ -17,7 +17,6 @@ export const peopleSchema: GenericCardSchema = {
   secondaryLabels: [
     'email',
     'orcidId',
-    'grantName',
     'consortium',
     'workingGroupParticipation',
     'synapseProfileLink',


### PR DESCRIPTION
In the Person card, we have `Grant Name` as one of the secondary labels, which is redundant with the "Related Grants" information on the details page.  Ergo, we'd like to remove the secondary label.