### PR TITLE
PORTALS-2157: Fix alignment issue

### DIFF
--- a/src/_Core.scss
+++ b/src/_Core.scss
@@ -733,6 +733,7 @@ div[data-id='tooltip'] {
     }
     .TotalQueryResults.hasFilters > * {
       margin-left: 0px;
+      margin-right: 0px;
     }
   }
 }


### PR DESCRIPTION
Some CSS changes caused an alignment issue with the TotalQueryResults section that this PR should fix.

## Explore Page

Before:

<img width="1264" alt="image" src="https://user-images.githubusercontent.com/17580037/198329044-2f1894c6-adce-4156-afa6-793a0ccc75ad.png">

After:

![image](https://user-images.githubusercontent.com/17580037/198330726-c99f3e65-55bb-4707-a210-e127c77e3f18.png)


## Details Page

Before:

<img width="1264" alt="image" src="https://user-images.githubusercontent.com/17580037/198329284-fae6f250-f6e0-4f7e-aa55-e9204bf83574.png">


After:

<img width="1264" alt="image" src="https://user-images.githubusercontent.com/17580037/198329314-7f2e76aa-6062-4abb-96a8-c3f973d7a77c.png">


