### PR TITLE
Grant name bug fix

### DIFF
--- a/src/configurations/cancercomplexity/routesConfig.ts
+++ b/src/configurations/cancercomplexity/routesConfig.ts
@@ -229,11 +229,11 @@ const routes: GenericRoute[] = [
                     },
                     {
                       name: 'CardContainerLogic',
-                      columnName: 'grantName',
+                      columnName: 'grantNumber',
                       title: 'Related Publications',
-                      tableSqlKeys: ['grantName'],
+                      tableSqlKeys: ['grantNumber'],
                       props: {
-                        sqlOperator: 'LIKE',
+                        sqlOperator: 'HAS',
                         sql: publicationSql,
                         ...publicationsCardConfiguration,
                         columnAliases,
@@ -241,11 +241,11 @@ const routes: GenericRoute[] = [
                     },
                     {
                       name: 'CardContainerLogic',
-                      columnName: 'grantName',
+                      columnName: 'grantNumber',
                       title: 'Related Datasets',
-                      tableSqlKeys: ['grantName'],
+                      tableSqlKeys: ['grantNumber'],
                       props: {
-                        sqlOperator: 'LIKE',
+                        sqlOperator: 'HAS',
                         sql: datasetsSql,
                         ...datasetCardConfiguration,
                         columnAliases,

--- a/src/configurations/cancercomplexity/routesConfig.ts
+++ b/src/configurations/cancercomplexity/routesConfig.ts
@@ -253,11 +253,11 @@ const routes: GenericRoute[] = [
                     },
                     {
                       name: 'CardContainerLogic',
-                      columnName: 'grantName',
+                      columnName: 'grantNumber',
                       title: 'Related Tools',
-                      tableSqlKeys: ['grantName'],
+                      tableSqlKeys: ['grantNumber'],
                       props: {
-                        sqlOperator: 'LIKE',
+                        sqlOperator: 'HAS',
                         sql: toolsSql,
                         ...toolsConfiguration,
                         columnAliases,

--- a/src/configurations/cancercomplexity/synapseConfigs/tools.ts
+++ b/src/configurations/cancercomplexity/synapseConfigs/tools.ts
@@ -40,18 +40,6 @@ export const toolsConfiguration: CardConfiguration = {
       isMarkdown: true,
       matchColumnName: 'downloadLink',
     },
-    {
-      isMarkdown: false,
-      URLColumnName: 'publicationTitle',
-      matchColumnName: 'publicationTitle',
-      baseURL: 'Explore/Publications/DetailsPage',
-    },
-    {
-      isMarkdown: false,
-      URLColumnName: 'grantName',
-      matchColumnName: 'grantName',
-      baseURL: 'Explore/Grants/DetailsPage',
-    },
   ],
 }
 
@@ -71,7 +59,6 @@ export const tools: SynapseConfig = {
         'publicationTitle',
         'inputData',
         'outputData',
-        'grantName',
       ],
     },
   },


### PR DESCRIPTION
From @aclayton555 :

> Hey there, I was poking around the CCKP in some of our recently added grants and noted that there seems to be a display issue with the "Related Tools" section on at least a couple of them. See example: https://www.cancercomplexity.synapse.org/Explore/Grants/DetailsPage?grantId=syn35270534#RelatedTools

I realize it's because I forgot to make some updates to the routes config after we switched to the new tools table.

In addition to the bug fix above, I also updated the related items routing to use `grantNumber` in general instead of `grantName`, since commas in the grant names result in multiple queries (thus resulting in duplicate cards), e.g. [Mechanical determinants of organ-selective metastatic colonization, dormancy and outgrowth](https://www.cancercomplexity.synapse.org/Explore/Grants/DetailsPage?grantId=syn35270534):

**Before**
![Screen Shot 2022-10-28 at 11 27 06 AM](https://user-images.githubusercontent.com/9377970/198709053-d65ad82c-fc14-4ac1-8a50-ffa28985faed.png)

**After**
![Screen Shot 2022-10-28 at 11 28 01 AM](https://user-images.githubusercontent.com/9377970/198709493-91ddd2c3-b6eb-4066-9137-09d59e8ed8c4.png)


