### PR TITLE
IT-2157: Fix news site url

### DIFF
--- a/src/configurations/arkportal/routesConfig.ts
+++ b/src/configurations/arkportal/routesConfig.ts
@@ -167,7 +167,7 @@ const routes: GenericRoute[] = [
     displayName: 'News',
     path: undefined,
     target: '_blank',
-    link: 'https://parkportalnews.wpengine.com/',
+    link: 'https://news.arkportal.org/',
     synapseConfigArray: [],
   },
   {


### PR DESCRIPTION
Quick fix...
@jay-hodgson , is that URL going to be a problem to display in the site itself (i.e. should it be https://news.arkportal.synapse.org)?