### PR TITLE
PORTALS-2439: always attempt to pull in snapshot in detail page

### DIFF
--- a/src/configurations/arkportal/synapseConfigs/data.ts
+++ b/src/configurations/arkportal/synapseConfigs/data.ts
@@ -18,6 +18,12 @@ export const dataColumnLinks: LabelLinkConfig = [
     baseURL: 'Explore/Programs/DetailsPage',
     URLColumnName: 'Program',
   },
+  {
+    matchColumnName: 'dataset',
+    isMarkdown: false,
+    baseURL: 'Explore/Datasets/DetailsPage',
+    URLColumnName: 'id',
+  },
 ]
 
 const data: SynapseConfig = {

--- a/src/configurations/arkportal/synapseConfigs/datasets.ts
+++ b/src/configurations/arkportal/synapseConfigs/datasets.ts
@@ -112,7 +112,7 @@ export const datasetDetailsPageConfig: DetailsPageProps = {
         defaultShowFacetVisualization: false
       },
       // tableSqlKeys: ['id'],  // Do not modify the sql where condition based on search params
-      overrideSqlSourceTable: true, // Instead, modify the sql (SELECT * FROM <search_param_value>)
+      overrideSqlSourceTable: true, // Instead, modify the sql (SELECT * FROM <search_param_value>).<rowVersionNumber>
       columnName: 'id',
     },
   ],

--- a/src/portal-components/DetailsPage/DetailsPage.tsx
+++ b/src/portal-components/DetailsPage/DetailsPage.tsx
@@ -208,6 +208,8 @@ const SynapseObject: React.FC<{
   const { columnName = '', resolveSynId, props, overrideSqlSourceTable } = el
   const deepCloneOfProps = cloneDeep(props)
   const row = queryResultBundle!.queryResult!.queryResults.rows[0].values
+  const rowVersionNumber = queryResultBundle!.queryResult!.queryResults.rows[0].versionNumber
+
   // map column name to index
   const mapColumnHeaderToRowIndex: Dictionary<{
     index: number
@@ -263,6 +265,7 @@ const SynapseObject: React.FC<{
           el={el}
           deepCloneOfProps={deepCloneOfProps}
           overrideSqlSourceTable={overrideSqlSourceTable}
+          rowVersionNumber={rowVersionNumber}
         />
       ))}
     </>
@@ -276,6 +279,7 @@ export const SplitStringToComponent: React.FC<{
   el: RowSynapseConfig
   deepCloneOfProps: any
   overrideSqlSourceTable?: boolean
+  rowVersionNumber?: number
 }> = ({
   splitString,
   resolveSynId,
@@ -283,6 +287,7 @@ export const SplitStringToComponent: React.FC<{
   el,
   deepCloneOfProps,
   overrideSqlSourceTable,
+  rowVersionNumber
 }) => {
   let value = splitString.trim()
   const valueIsSynId = React.useMemo(
@@ -333,7 +338,7 @@ export const SplitStringToComponent: React.FC<{
   })
   if (overrideSqlSourceTable) {
     // use the search param value to override the sql param.
-    injectedProps['sql'] = `SELECT  *  FROM  ${value}`
+    injectedProps['sql'] = `SELECT  *  FROM  ${value}.${rowVersionNumber}`
   }
 
   // For explorer 2.0, cannot assign key `lockedColumn` to deepCloneOfProps due to type errors,

--- a/src/types/portal-util-types.ts
+++ b/src/types/portal-util-types.ts
@@ -29,7 +29,7 @@ type RowToPropTransform = {
   columnName?: string
   injectMarkdown?: boolean
   showTitleSeperator?: boolean
-  overrideSqlSourceTable?: boolean
+  overrideSqlSourceTable?: boolean // use the search param value for the table sql:  SELECT * FROM <search-param-value>.<rowVersionNumber>
   toggleConfigs?: ToggleConfigs // PORTALS-2229: set if we should show a toggle
 }
 


### PR DESCRIPTION
this will show an error if the snapshot does not exist, which should tell the portal owner to lock down the data so that it can be downloaded